### PR TITLE
fix: Release executable jar

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,9 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: main # For spotless ratchet feature
+      - uses: actions/checkout@v4
       - uses: arduino/setup-task@v2
       - uses: actions/setup-java@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,8 +67,9 @@ jobs:
           ORG_GRADLE_PROJECT_releaseVersion: ${{ env.RELEASE_VERSION }}
       - name: Calculate sha256
         run: |
-          mv ./protoc-gen-connect-ktor/build/libs/protoc-gen-connect-ktor-${{ env.RELEASE_VERSION }}.jar .
-          sha256sum protoc-gen-connect-ktor-${{ env.RELEASE_VERSION }}.jar >> sha256.txt
+          mv ./protoc-gen-connect-ktor/build/bin/protoc-gen-connect-ktor ./
+          mv ./protoc-gen-connect-ktor/build/bin/protoc-gen-connect-ktor.bat ./
+          sha256sum protoc-gen-connect-ktor >> sha256.txt
       - name: Publish GitHub artifacts
         uses: softprops/action-gh-release@v2
         with:
@@ -76,5 +77,6 @@ jobs:
           generate_release_notes: true
           append_body: true
           files: |
-            protoc-gen-connect-ktor-${{ env.RELEASE_VERSION }}.jar
+            protoc-gen-connect-ktor
+            protoc-gen-connect-ktor.bat
             sha256.txt

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -15,7 +15,7 @@ tasks:
     aliases:
       - build-pp
     cmds:
-      - ./gradlew :protoc-gen-connect-ktor:installDist -x test
+      - ./gradlew :protoc-gen-connect-ktor:shadowJarExecutable -x test
   test:
     deps:
       - generate

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,6 +27,7 @@ allprojects {
 
     repositories {
         mavenCentral()
+        gradlePluginPortal()
     }
 
     apply(plugin = "com.diffplug.spotless")
@@ -50,6 +51,10 @@ allprojects {
             )
             target("**/*.kts")
         }
+    }
+
+    tasks.withType<Test> {
+        useJUnitPlatform()
     }
 
     tasks.withType<Jar>().configureEach {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@ kotlin = "2.0.21"
 kotlinx-serialization = "1.7.3"
 maven-publish = "0.30.0"
 spotless = "6.25.0"
+shadow = "8.3.5"
 
 connect = "0.7.0"
 ktor = "3.0.0"
@@ -19,6 +20,7 @@ kotest = "5.9.1"
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
+shadow = { id = "com.gradleup.shadow", version.ref = "shadow" }
 
 [libraries]
 kotlin-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }

--- a/protoc-gen-connect-ktor/src/test/resources/buf.gen.yaml
+++ b/protoc-gen-connect-ktor/src/test/resources/buf.gen.yaml
@@ -12,5 +12,5 @@ plugins:
     out: build/generated/sources/bufgen
   - remote: buf.build/connectrpc/kotlin:v0.7.0
     out: build/generated/sources/bufgen
-  - local: ./protoc-gen-connect-ktor/build/install/protoc-gen-connect-ktor/bin/protoc-gen-connect-ktor
+  - local: ./protoc-gen-connect-ktor/build/bin/protoc-gen-connect-ktor
     out: build/generated/sources/bufgen


### PR DESCRIPTION
This pull request includes several changes to the build and release process, focusing on switching to the Shadow plugin for creating executable JARs and updating the build configuration accordingly. The most important changes are outlined below:

### Build Configuration Updates:
* Updated the `Taskfile.yaml` to use the `shadowJarExecutable` task instead of `installDist` for building the project (`Taskfile.yaml`).
* Added the Shadow plugin to the `gradle/libs.versions.toml` and `protoc-gen-connect-ktor/build.gradle.kts` files to support creating executable JARs (`gradle/libs.versions.toml`, `protoc-gen-connect-ktor/build.gradle.kts`) [[1]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfR6) [[2]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfR23) [[3]](diffhunk://#diff-597d701851e6ca98ab45504db4d4f11f8b63e62aa155087cf79283cb3c4fda36R8).

### Release Workflow Changes:
* Modified the `.github/workflows/release.yml` to move the generated executable files and calculate their SHA256 checksums (`.github/workflows/release.yml`).

### Task and Plugin Adjustments:
* Introduced a new `shadowJarExecutable` task in `protoc-gen-connect-ktor/build.gradle.kts` to create self-executable JAR files for both Unix and Windows systems (`protoc-gen-connect-ktor/build.gradle.kts`).
* Updated the `buf.gen.yaml` configuration to reflect the new path for the generated executable (`protoc-gen-connect-ktor/src/test/resources/buf.gen.yaml`).