### PR TITLE
feat: Add support for proto serialization/deserialization

### DIFF
--- a/ktor-serialization-connect/src/main/kotlin/io/github/ichizero/ktor/serialization/connect/Configuration.kt
+++ b/ktor-serialization-connect/src/main/kotlin/io/github/ichizero/ktor/serialization/connect/Configuration.kt
@@ -3,13 +3,30 @@ package io.github.ichizero.ktor.serialization.connect
 import io.ktor.http.ContentType
 import io.ktor.serialization.Configuration
 
+object ConnectContentType {
+    internal val Json = ContentType.Application.Json
+    internal val ConnectJson = ContentType("application", "connect+json")
+
+    internal val Proto = ContentType("application", "proto")
+    internal val ConnectProto = ContentType("application", "connect+proto")
+}
+
 internal val contentTypeConnectJson = ContentType("application", "connect+json")
 
 /**
- * Registers the `application/connect+json` content type
+ * Registers `application/json` and `application/connect+json` content type
  * to the [ContentNegotiation] plugin using [ConnectJsonConverter].
  */
 fun Configuration.connectJson() {
-    register(ContentType.Application.Json, ConnectJsonConverter()) // For unary RPCs
-    register(contentTypeConnectJson, ConnectJsonConverter()) // For bidirectional and server streaming RPCs
+    register(ConnectContentType.Json, ConnectJsonConverter()) // For unary RPCs
+    register(ConnectContentType.ConnectJson, ConnectJsonConverter()) // For bidirectional and server streaming RPCs
+}
+
+/**
+ * Registers `application/proto` and `application/connect+proto` content type
+ * to the [ContentNegotiation] plugin using [ConnectJsonConverter].
+ */
+fun Configuration.connectProto() {
+    register(ConnectContentType.Proto, ConnectProtoConverter()) // For unary RPCs
+    register(ConnectContentType.ConnectProto, ConnectProtoConverter()) // For bidirectional and server streaming RPCs
 }

--- a/ktor-serialization-connect/src/main/kotlin/io/github/ichizero/ktor/serialization/connect/ConnectProtoConverter.kt
+++ b/ktor-serialization-connect/src/main/kotlin/io/github/ichizero/ktor/serialization/connect/ConnectProtoConverter.kt
@@ -1,6 +1,6 @@
 package io.github.ichizero.ktor.serialization.connect
 
-import com.connectrpc.extensions.GoogleJavaJSONStrategy
+import com.connectrpc.extensions.GoogleJavaProtobufStrategy
 import io.ktor.http.*
 import io.ktor.http.content.*
 import io.ktor.serialization.*
@@ -14,10 +14,10 @@ import okio.source
 import kotlin.reflect.KClass
 
 /**
- * A JSON content converter for Connect Protocol.
+ * A binary content converter for Connect Protocol.
  */
-class ConnectJsonConverter : ContentConverter {
-    private val serializationStrategy = GoogleJavaJSONStrategy()
+class ConnectProtoConverter : ContentConverter {
+    private val serializationStrategy = GoogleJavaProtobufStrategy()
 
     override suspend fun serialize(
         contentType: ContentType,
@@ -30,11 +30,11 @@ class ConnectJsonConverter : ContentConverter {
         if (value == null) return TextContent("null", ct)
 
         @Suppress("UNCHECKED_CAST")
-        return TextContent(
-            text = serializationStrategy
+        return ByteArrayContent(
+            bytes = serializationStrategy
                 .codec(typeInfo.type as KClass<Any>)
                 .serialize(value)
-                .readString(charset),
+                .readByteArray(),
             contentType = ct,
         )
     }

--- a/ktor-serialization-connect/src/test/kotlin/io/github/ichizero/ktor/serialization/connect/ConnectProtoConverterTest.kt
+++ b/ktor-serialization-connect/src/test/kotlin/io/github/ichizero/ktor/serialization/connect/ConnectProtoConverterTest.kt
@@ -1,0 +1,44 @@
+package io.github.ichizero.ktor.serialization.connect
+
+import com.connectrpc.eliza.v1.SayRequest
+import com.connectrpc.eliza.v1.sayRequest
+import io.kotest.assertions.json.*
+import io.kotest.core.spec.style.*
+import io.kotest.matchers.*
+import io.ktor.http.content.*
+import io.ktor.util.reflect.*
+import io.ktor.utils.io.jvm.javaio.*
+
+class ConnectProtoConverterTest : FunSpec({
+    test("serialize then deserialize") {
+        val target = sayRequest {
+            sentence = "hello"
+        }
+
+        val serialized = ConnectProtoConverter().serialize(
+            contentType = contentTypeConnectJson,
+            charset = Charsets.UTF_8,
+            typeInfo = TypeInfo(SayRequest::class),
+            value = target,
+        ) as ByteArrayContent
+
+        // Note: https://protobuf.dev/programming-guides/encoding/
+        serialized.bytes() shouldBe byteArrayOf(
+            0b0000_1010,
+            0b0000_0101,
+            'h'.code.toByte(),
+            'e'.code.toByte(),
+            'l'.code.toByte(),
+            'l'.code.toByte(),
+            'o'.code.toByte(),
+        )
+
+        val deserialized = ConnectProtoConverter().deserialize(
+            charset = Charsets.UTF_8,
+            typeInfo = TypeInfo(SayRequest::class),
+            content = serialized.bytes().inputStream().toByteReadChannel(),
+        ) as SayRequest
+
+        deserialized shouldBe target
+    }
+})


### PR DESCRIPTION
This pull request introduces support for `application/proto` and `application/connect+proto` content types, alongside improvements and tests for the existing JSON content types in the `ktor-serialization-connect` package.

### New Features:
* Added support for `application/proto` and `application/connect+proto` content types with the new `ConnectProtoConverter` class. (`ktor-serialization-connect/src/main/kotlin/io/github/ichizero/ktor/serialization/connect/ConnectProtoConverter.kt`)
* Introduced the `ConnectContentType` object to centralize content type definitions. (`ktor-serialization-connect/src/main/kotlin/io/github/ichizero/ktor/serialization/connect/Configuration.kt`)

### Enhancements:
* Updated `Configuration.connectJson` to use the new `ConnectContentType` object. (`ktor-serialization-connect/src/main/kotlin/io/github/ichizero/ktor/serialization/connect/Configuration.kt`)
* Added `Configuration.connectProto` to register the new proto content types. (`ktor-serialization-connect/src/main/kotlin/io/github/ichizero/ktor/serialization/connect/Configuration.kt`)

### Tests:
* Created `ConfigurationConnectProtoTest` to verify the new proto content type support. (`ktor-serialization-connect/src/test/kotlin/io/github/ichizero/ktor/serialization/connect/ConfigurationTest.kt`)
* Added `ConnectProtoConverterTest` to test serialization and deserialization of proto content. (`ktor-serialization-connect/src/test/kotlin/io/github/ichizero/ktor/serialization/connect/ConnectProtoConverterTest.kt`)

### Minor Changes:
* Updated `ConnectJsonConverter` documentation to specify it is a JSON content converter. (`ktor-serialization-connect/src/main/kotlin/io/github/ichizero/ktor/serialization/connect/ConnectJsonConverter.kt`)
* Renamed `ConfigurationTest` to `ConfigurationConnectJsonTest` and adjusted test cases accordingly. (`ktor-serialization-connect/src/test/kotlin/io/github/ichizero/ktor/serialization/connect/ConfigurationTest.kt`) [[1]](diffhunk://#diff-c79a5a9bd2c6cffec3963eb6217b4af1fa2ca874748e66ebe194ef75bd8ee8ceL31-R32) [[2]](diffhunk://#diff-c79a5a9bd2c6cffec3963eb6217b4af1fa2ca874748e66ebe194ef75bd8ee8ceL81-R82)