### PR TITLE
fix(protoc-gen-connect-ktor): Correct input type in route handler definition

### DIFF
--- a/protoc-gen-connect-ktor/template.go
+++ b/protoc-gen-connect-ktor/template.go
@@ -57,7 +57,7 @@ interface {{ .Name }}HandlerInterface {
 
 fun Route.{{ .Name | toLowerFirst }}(handler: {{ .Name }}HandlerInterface) {
     {{- range .Methods }}
-    post<{{ $.Name }}HandlerInterface.Procedures.{{ .Name }}, SayRequest>(handle(handler::{{ .Name | toLowerFirst }}))
+    post<{{ $.Name }}HandlerInterface.Procedures.{{ .Name }}, {{ .InputTypeName }}>(handle(handler::{{ .Name | toLowerFirst }}))
     {{- end }}
 }
 `


### PR DESCRIPTION
This pull request includes a change in the `protoc-gen-connect-ktor/template.go` file to improve type consistency for the input type in the `post` method.

* [`protoc-gen-connect-ktor/template.go`](diffhunk://#diff-766cd81ff1b3dbd7085425998e2cd328a1f3800a38b958aa41149f223c81d50fL60-R60): Changed the input type from `SayRequest` to `{{ .InputTypeName }}` in the `post` method to ensure it dynamically matches the input type defined for each method.