### PR TITLE
ci: add OSSF Scorecard analysis workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -16,7 +16,7 @@ jobs:
     permissions:
       # Needed for Code scanning upload
       security-events: write
-      # Needed if publish_results: true (read is already covered by top-level read-all)
+      # Needed if publish_results: true
       id-token: write
 
     steps:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -17,7 +17,7 @@ jobs:
       # Needed for Code scanning upload
       security-events: write
       # Needed if publish_results: true (read is already covered by top-level read-all)
-      # id-token: write
+      id-token: write
 
     steps:
       - name: "Checkout code"
@@ -30,7 +30,7 @@ jobs:
         with:
           results_file: results.sarif
           results_format: sarif
-          publish_results: false
+          publish_results: true
 
       - name: "Upload artifact"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,45 @@
+name: Scorecard supply-chain security
+on:
+  push:
+    branches:
+      - main
+  # Weekly run at 09:00 UTC on Friday (18:00 JST Friday)
+  schedule:
+    - cron: '0 9 * * 5'
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed for Code scanning upload
+      security-events: write
+      # Needed if publish_results: true (read is already covered by top-level read-all)
+      # id-token: write
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: false
+
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -7,13 +7,13 @@ on:
   schedule:
     - cron: '0 9 * * 5'
 
-permissions: read-all
-
 jobs:
   analysis:
     name: Scorecard analysis
     runs-on: ubuntu-latest
     permissions:
+      # Needed by scorecard-action to read repository data via GraphQL
+      contents: read
       # Needed for Code scanning upload
       security-events: write
       # Needed if publish_results: true

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 ![CI](https://github.com/ichizero/connect-ktor/actions/workflows/ci.yml/badge.svg)
 ![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/ichizero/connect-ktor?utm_source=oss&utm_medium=github&utm_campaign=ichizero%2Fconnect-ktor&labelColor=171717&color=FF570A&link=https%3A%2F%2Fcoderabbit.ai&label=CodeRabbit+Reviews)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/ichizero/connect-ktor/badge)](https://scorecard.dev/viewer/?uri=github.com/ichizero/connect-ktor)
 
 Connect-Ktor is a library developed as an extension of
 [Connect-Kotlin](https://github.com/connectrpc/connect-kotlin)


### PR DESCRIPTION
## Summary
- Add `.github/workflows/scorecard.yml` to run [OSSF Scorecard](https://github.com/ossf/scorecard) supply-chain security analysis
- Triggers: push to `main` and weekly schedule (Friday 18:00 JST / 09:00 UTC)
- Uploads SARIF results as an artifact and to GitHub code scanning

## Test plan
- [ ] Workflow runs successfully on push to this branch's PR base after merge
- [ ] SARIF results appear in the Security > Code scanning tab

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated supply-chain security scanning workflow that runs on pushes to the main branch and weekly.

* **Documentation**
  * Added OpenSSF Scorecard badge to the README.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ichizero/connect-ktor/pull/201?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->