### PR TITLE
ci: add CodeQL advanced setup workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,72 @@
+name: codeql
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  # Weekly run at 09:00 UTC on Friday (18:00 JST Friday)
+  schedule:
+    - cron: '0 9 * * 5'
+permissions:
+  contents: read
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+          - language: go
+            build-mode: autobuild
+          - language: java-kotlin
+            build-mode: manual
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - if: matrix.language == 'java-kotlin'
+        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
+      - if: matrix.language == 'java-kotlin'
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: gradle
+      - if: matrix.language == 'java-kotlin' || matrix.language == 'go'
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: "./protoc-gen-connect-ktor/go.mod"
+          cache-dependency-path: "./protoc-gen-connect-ktor/go.sum"
+      - if: matrix.language == 'java-kotlin'
+        uses: bufbuild/buf-setup-action@a47c93e0b1648d5651a065437926377d060baa99 # v1.50.0
+        with:
+          github_token: ${{ github.token }}
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - if: matrix.language == 'java-kotlin'
+        name: Build project
+        run: |
+          task generate
+          ./gradlew --no-daemon classes testClasses
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary
- Add CodeQL advanced-setup workflow covering `actions`, `go`, and `java-kotlin`.
- `java-kotlin` uses `build-mode: manual` and runs `task build` so that the locally built `protoc-gen-connect-ktor` Go binary is produced and `buf generate` succeeds before Kotlin compilation.
- Default setup's autobuild fails because `:conformance:bufGenerate` shells out to the `buf` CLI (not present on the CodeQL runner) and depends on the locally built protoc plugin.

## Why not default setup + buf-gradle-plugin
`buf.gen.yaml` references `local: ../protoc-gen-connect-ktor/out/protoc-gen-connect-ktor`. Even if buf-gradle-plugin provisioned the buf CLI, the autobuild step cannot build the Go plugin, so default setup remains unworkable.

## Test plan
- [ ] CodeQL workflow runs green on this PR
- [ ] Disable the GitHub-managed default CodeQL setup before merging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled automated code quality and security scanning for the repository, running on code pushes, pull requests to main, and weekly schedules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ichizero/connect-ktor/pull/205?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->