### PR TITLE
build: generate SBOM for library and protoc-gen-connect-ktor

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,17 @@ jobs:
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_PASSPHRASE }}
           ORG_GRADLE_PROJECT_releaseVersion: ${{ env.RELEASE_VERSION }}
+
+      - name: Generate CycloneDX SBOM
+        run: ./gradlew :library:cyclonedxBom
+        env:
+          ORG_GRADLE_PROJECT_releaseVersion: ${{ env.RELEASE_VERSION }}
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: connect-ktor-sbom
+          path: library/build/reports/bom.json
+          if-no-files-found: error
   plugin:
     runs-on: ubuntu-latest
     permissions:
@@ -62,6 +73,9 @@ jobs:
           go-version-file: "./protoc-gen-connect-ktor/go.mod"
           cache-dependency-path: "./protoc-gen-connect-ktor/go.sum"
           cache: false
+
+      - name: Install syft
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
 
       - uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,9 @@ permissions:
 jobs:
   library:
     runs-on: ubuntu-latest
+    needs: plugin
     permissions:
-      contents: read
+      contents: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -52,12 +53,14 @@ jobs:
         run: ./gradlew :library:cyclonedxBom
         env:
           ORG_GRADLE_PROJECT_releaseVersion: ${{ env.RELEASE_VERSION }}
-      - name: Upload SBOM artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: connect-ktor-sbom
-          path: library/build/reports/bom.json
-          if-no-files-found: error
+      - name: Attach SBOM to GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="${GITHUB_REF#refs/tags/}"
+          gh release upload "$tag" \
+            "library/build/reports/bom.json#library-${RELEASE_VERSION}-cyclonedx.json" \
+            --clobber
   plugin:
     runs-on: ubuntu-latest
     permissions:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -35,6 +35,9 @@ archives:
       - goos: windows
         formats: zip
 
+sboms:
+  - artifacts: archive
+
 changelog:
   sort: asc
   filters:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -37,6 +37,13 @@ archives:
 
 sboms:
   - artifacts: archive
+    documents:
+      - "${artifact}.cdx.sbom.json"
+    cmd: syft
+    args:
+      - "$artifact"
+      - "--output"
+      - "cyclonedx-json=$document"
 
 changelog:
   sort: asc

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@ kotlin = "2.3.21"
 kotlinx-serialization = "1.11.0"
 maven-publish = "0.36.0"
 spotless = "8.5.1"
+cyclonedx = "3.2.4"
 
 connect = "0.8.2"
 ktor = "3.5.0"
@@ -20,6 +21,7 @@ kotest = "5.9.1"
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
+cyclonedx-bom = { id = "org.cyclonedx.bom", version.ref = "cyclonedx" }
 
 [libraries]
 kotlin-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -1,9 +1,18 @@
 import com.vanniktech.maven.publish.KotlinJvm
+import org.cyclonedx.gradle.CyclonedxDirectTask
 
 plugins {
     kotlin("jvm")
     alias(libs.plugins.kotlinx.serialization)
+    alias(libs.plugins.cyclonedx.bom)
     id("com.vanniktech.maven.publish.base")
+}
+
+tasks.named<CyclonedxDirectTask>("cyclonedxDirectBom") {
+    schemaVersion.set(org.cyclonedx.Version.VERSION_16)
+    jsonOutput.set(layout.buildDirectory.file("reports/bom.json"))
+    xmlOutput.set(layout.buildDirectory.file("reports/bom.xml"))
+    includeConfigs.set(listOf("runtimeClasspath"))
 }
 
 kotlin {


### PR DESCRIPTION
## Summary

Publishes a CycloneDX 1.6 Software Bill of Materials for every release of `connect-ktor`, covering both the published Kotlin library and the Go `protoc-gen-connect-ktor` binaries.

Today consumers have no machine-readable manifest of what `io.github.ichizero:library` actually ships with, which makes downstream CVE impact analysis (e.g. correlating a Ktor / kotlinx-serialization advisory against pinned versions) a manual `gradle dependencies` exercise. The plugin tarballs are in the same position. This PR closes that gap by attaching a per-artifact SBOM to every release, so:

- Downstream users can ingest `library-<version>-cyclonedx.json` / `*.cdx.sbom.json` directly into their vulnerability scanners.
- Future supply-chain primitives (signing, SLSA attestation) have a stable artifact to hash and attest.

This is also the foundation PR for a follow-up that adds cosign signatures + SLSA build provenance on top of these SBOMs.

## What changed

- **`library` (Kotlin)** — apply the [`org.cyclonedx.bom`](https://github.com/CycloneDX/cyclonedx-gradle-plugin) Gradle plugin v3.2.4 on the published module only. Configured to emit CycloneDX **1.6 JSON** at `library/build/reports/bom.json`, scoped to the `runtimeClasspath` configuration. v3.x is required because v1.x of the plugin caps at CycloneDX spec 1.5.
- **`protoc-gen-connect-ktor` (Go)** — add an explicit `sboms:` block to `.goreleaser.yaml` that invokes `syft` with `--output cyclonedx-json` per release archive. Outputs land at `<archive>.cdx.sbom.json` as siblings of each archive in `dist/`, and GoReleaser uploads them as GitHub Release assets alongside the binaries. GoReleaser's default behavior emits SPDX 2.3 instead, which would have made the two halves of the project ship two different SBOM formats — overridden here to keep everything CycloneDX 1.6.
- **`.github/workflows/release.yml`**
  - `plugin` job: install `syft` via `anchore/sbom-action/download-syft` before GoReleaser runs. The `download-syft` sub-action only puts `syft` on `PATH`; SBOM generation itself is owned by GoReleaser to avoid double-attachment. GoReleaser creates the draft GitHub Release at `release: draft: true`.
  - `library` job: gain `needs: plugin` so the draft release already exists; run `./gradlew :library:cyclonedxBom` after the Maven Central publish step and `gh release upload "$tag" library/build/reports/bom.json#library-${VERSION}-cyclonedx.json --clobber` to attach the BOM as a Release asset (renamed from the generic `bom.json` for clarity on the release page). Required `contents: write` so the same job that publishes can also upload to the Release; the workflow-level default stays `contents: read`.
- Only `:library` is SBOM'd on the Kotlin side. `:conformance` is internal test infrastructure and not published.

### Action SHAs added

| Action | Version | SHA |
|---|---|---|
| `anchore/sbom-action/download-syft` | v0.24.0 | `e22c3899…` |

## Decision points

| Question | Decision | Why |
|---|---|---|
| CycloneDX spec level? | **1.6** | Latest stable spec; 1.6 adds component lifecycle and external reference improvements that vulnerability scanners (OSV-Scanner, Grype, Trivy) already understand. |
| CycloneDX Gradle plugin major? | **v3.2.4** | v1.x maxes out at spec 1.5; v3.x is the only line that emits 1.6 JSON. v2.x is an internal-only line that never shipped 1.6. |
| Configuration scope for the BOM? | **`runtimeClasspath` only** | What downstream consumers actually pull transitively when they declare a runtime dependency on the library. Including `compileClasspath` would leak `@Annotation` and `kotlin-stdlib-common` style entries that aren't on the runtime path. |
| SBOM for `:conformance`? | **No** | Not published; conformance is an internal cross-engine test harness. Including it would publish CVEs against test-only deps and confuse scanners. |
| Kotlin SBOM = CycloneDX, Go SBOM left at GoReleaser default (SPDX)? | **Force CycloneDX on the Go side too** | Verified locally that GoReleaser's default `syft` invocation produces SPDX 2.3 `.sbom.json`. Mixing SPDX (Go) and CycloneDX (Kotlin) would force consumers to parse both formats; overrode `sboms.cmd`/`args` so syft emits CycloneDX 1.6 for both halves. |
| Where does the Kotlin BOM get attached? | **GitHub Release asset (not workflow-run artifact, not Maven Central)** | Sonatype rejects unknown classifiers on published GAVs, and `actions/upload-artifact` only stores files as workflow-run artifacts which downstream consumers cannot fetch. `gh release upload` attaches the BOM to the same Release page where the Go binaries live, giving consumers and future cosign/SLSA verifiers a single canonical location. |
| `library` runs before or after `plugin`? | **`needs: plugin`** | GoReleaser is what creates the draft Release. The library job's `gh release upload` would race-fail against a not-yet-existing release if the two ran in parallel. Ordering also keeps the Release page predictable: Go binaries first (auto-populated by GoReleaser), then the Kotlin BOM uploaded on top. |
| Release object mutability after publish? | **Safe** | `.goreleaser.yaml` has `release: { draft: true }` so the Release is mutable while CI runs. Both jobs only ever touch the draft state; once the maintainer manually publishes the draft (and the immutable-releases setting takes effect), there are no further CI writes. |
| Asset name on the Release? | **`library-${VERSION}-cyclonedx.json`** | The raw `bom.json` filename has no version or library identifier, which is confusing next to versioned `connect-ktor_*` archives produced by GoReleaser. Renaming on upload (`path#name` syntax) keeps it self-describing without changing the in-repo file path. |
| `anchore/sbom-action` vs `anchore/sbom-action/download-syft`? | **`download-syft` sub-action** | The top-level action *generates* an SBOM itself, which would race / double-attach against GoReleaser's own `sboms:` step. The sub-action only installs the `syft` binary on `PATH`, leaving generation to GoReleaser. |
| Why not OWASP Dependency-Track / Maven SBOM plugin? | **Stayed with CycloneDX Gradle plugin** | Dependency-Track is a *consumer* of SBOMs, not a generator; the Maven SBOM plugin doesn't fit a Gradle build. The CycloneDX Gradle plugin is the upstream-recommended generator for Gradle projects. |

## Commits

| Commit | Purpose |
|---|---|
| `ac05d5f build: generate SBOM for library and protoc-gen-connect-ktor` | Apply CycloneDX plugin to `:library`, wire `cyclonedxBom` into the release workflow; add `sboms:` to `.goreleaser.yaml` and install `syft` in the plugin release job. |
| `29eb50c build: emit CycloneDX SBOM from GoReleaser instead of SPDX` | Override GoReleaser's default SPDX output: invoke `syft` with `--output cyclonedx-json`, write to `${artifact}.cdx.sbom.json`. Brings Go archive SBOMs in line with the Kotlin library SBOM. |
| `36488e1 ci: attach library SBOM to the GitHub Release instead of workflow artifacts` | Replace `actions/upload-artifact` with `gh release upload`, add `needs: plugin` to serialize against the GoReleaser draft, widen `library` job permissions to `contents: write`, and rename the asset to `library-${VERSION}-cyclonedx.json` on the Release. |

## Test plan

- [x] `./gradlew :library:cyclonedxBom` succeeds locally; `library/build/reports/bom.json` parses as valid JSON with `"bomFormat": "CycloneDX"` and `"specVersion": "1.6"`, 76 components on the runtime classpath.
- [x] `goreleaser release --snapshot --clean --skip=publish` produces six `dist/*.cdx.sbom.json` siblings (Darwin/Linux/Windows × amd64/arm64); each validates as CycloneDX 1.6 JSON; archive content (`tar tzf`) confirms SBOMs are NOT bundled inside archives but uploaded as separate Release assets.
- [ ] Next release tag push: `plugin` job creates draft Release with all archives + `*.cdx.sbom.json`; `library` job (which now `needs: plugin`) uploads `library-${VERSION}-cyclonedx.json` to the same Release; maintainer publishes the draft.
- [ ] Run `osv-scanner --sbom library/build/reports/bom.json` against the generated BOM to confirm it's ingestable by a real scanner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Releases now include Software Bill of Materials (SBOM) artifacts in CycloneDX JSON format for your review.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ichizero/connect-ktor/pull/210?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->