### PR TITLE
release: sign Go artifacts with cosign and add SLSA build provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ jobs:
     needs: plugin
     permissions:
       contents: write
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -40,6 +42,13 @@ jobs:
         run: task build
         env:
           ORG_GRADLE_PROJECT_releaseVersion: ${{ env.RELEASE_VERSION }}
+
+      - name: Generate SLSA build provenance for library JARs
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: |
+            library/build/libs/*.jar
+
       - name: Publish to Central Repository
         run: ./gradlew publishToMavenCentral --no-configuration-cache
         env:
@@ -65,6 +74,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -80,9 +91,19 @@ jobs:
       - name: Install syft
         uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
       - uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
+
+      - name: Generate SLSA build provenance for Go release archives
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: |
+            dist/*.tar.gz
+            dist/*.zip

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -45,6 +45,18 @@ sboms:
       - "--output"
       - "cyclonedx-json=$document"
 
+signs:
+  - cmd: cosign
+    certificate: "${artifact}.pem"
+    args:
+      - sign-blob
+      - "--output-certificate=${certificate}"
+      - "--output-signature=${signature}"
+      - "${artifact}"
+      - --yes
+    artifacts: all
+    output: true
+
 changelog:
   sort: asc
   filters:

--- a/README.md
+++ b/README.md
@@ -255,9 +255,9 @@ by [cosign](https://github.com/sigstore/cosign) keyless signing via GitHub OIDC:
 cosign verify-blob \
   --certificate-identity-regexp "^https://github.com/ichizero/connect-ktor/\\.github/workflows/release\\.yml@refs/tags/v.*$" \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  --signature protoc-gen-connect-ktor_Linux_x86_64.tar.gz.sig \
-  --certificate protoc-gen-connect-ktor_Linux_x86_64.tar.gz.pem \
-  protoc-gen-connect-ktor_Linux_x86_64.tar.gz
+  --signature connect-ktor_Linux_x86_64.tar.gz.sig \
+  --certificate connect-ktor_Linux_x86_64.tar.gz.pem \
+  connect-ktor_Linux_x86_64.tar.gz
 ```
 
 ### Verify SLSA build provenance
@@ -266,7 +266,7 @@ Every release archive (Go binaries and library JARs) is published with a SLSA bu
 attestation. Verify it with the GitHub CLI:
 
 ```sh
-gh attestation verify protoc-gen-connect-ktor_Linux_x86_64.tar.gz \
+gh attestation verify connect-ktor_Linux_x86_64.tar.gz \
   --repo ichizero/connect-ktor
 ```
 

--- a/README.md
+++ b/README.md
@@ -241,6 +241,35 @@ fun main() {
 }
 ```
 
+## Verifying release artifacts
+
+Releases for the `protoc-gen-connect-ktor` Go binaries and the `library` JARs publish supply-chain
+metadata so consumers can verify provenance and integrity.
+
+### Verify the protoc-gen-connect-ktor archive signature with cosign
+
+Each release archive ships with a detached signature (`*.sig`) and certificate (`*.pem`) produced
+by [cosign](https://github.com/sigstore/cosign) keyless signing via GitHub OIDC:
+
+```sh
+cosign verify-blob \
+  --certificate-identity-regexp "^https://github.com/ichizero/connect-ktor/\\.github/workflows/release\\.yml@refs/tags/v.*$" \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --signature protoc-gen-connect-ktor_Linux_x86_64.tar.gz.sig \
+  --certificate protoc-gen-connect-ktor_Linux_x86_64.tar.gz.pem \
+  protoc-gen-connect-ktor_Linux_x86_64.tar.gz
+```
+
+### Verify SLSA build provenance
+
+Every release archive (Go binaries and library JARs) is published with a SLSA build provenance
+attestation. Verify it with the GitHub CLI:
+
+```sh
+gh attestation verify protoc-gen-connect-ktor_Linux_x86_64.tar.gz \
+  --repo ichizero/connect-ktor
+```
+
 ## License
 
 Offered under the [Apache 2 license](https://github.com/ichizero/connect-ktor/blob/main/LICENSE).


### PR DESCRIPTION
## Summary

Adds verifiable supply-chain primitives on top of the SBOMs introduced in #210:

- **Sigstore keyless signatures** on every Go release archive (`protoc-gen-connect-ktor`) via cosign, using GitHub OIDC. Each archive ships a co-located `.sig` + `.pem` so consumers can `cosign verify-blob` without trusting a long-lived key.
- **SLSA build provenance** for both the published Kotlin library JARs and the Go release archives, written through `actions/attest-build-provenance`. Provenance is attached to the same GitHub Release the artifacts live on, so `gh attestation verify` and `slsa-verifier` can answer "which workflow built this exact byte sequence" against an unbroken in-toto attestation.

The Kotlin library JAR is already GPG-signed via Sonatype, so this PR does not re-sign the JAR — it only adds the additional SLSA attestation pathway that aligns with GitHub's native attestations UI and is what most provenance-aware downstream tooling now expects.

Stacked on top of #210 (now merged). PR6 of the security blueprint series.

## What changed

- **`.goreleaser.yaml`** — add a `signs:` block invoking `cosign sign-blob --yes` per archive. Outputs `${artifact}.sig` (raw signature) and `${artifact}.pem` (the OIDC-bound short-lived certificate). `artifacts: all` covers all GoReleaser-produced files including the SBOMs from #210 so the supply-chain story is end-to-end.
- **`.github/workflows/release.yml`**
  - `library` job: gain `id-token: write` + `attestations: write` and add an `actions/attest-build-provenance` step over `library/build/libs/*.jar` before the Maven Central publish. `contents: write` is preserved (still needed for the SBOM `gh release upload` from #210).
  - `plugin` job: gain `id-token: write` + `attestations: write`, install `cosign` via `sigstore/cosign-installer` before GoReleaser, and add a second `actions/attest-build-provenance` step over `dist/*.tar.gz` and `dist/*.zip` after GoReleaser publishes.
- **`README.md`** — new "Verifying release artifacts" section documenting both verification flows:
  - `cosign verify-blob --certificate-identity-regexp '^https://github.com/ichizero/connect-ktor/\.github/workflows/release\.yml@refs/tags/v.*$' --certificate-oidc-issuer https://token.actions.githubusercontent.com --signature <archive>.sig --certificate <archive>.pem <archive>`
  - `gh attestation verify <artifact> --repo ichizero/connect-ktor`

### Action SHAs added

| Action | Version | SHA |
|---|---|---|
| `sigstore/cosign-installer` | v4.1.2 | `6f9f1778…` |
| `actions/attest-build-provenance` | v4.1.0 | `a2bbfa25…` (used in both `library` and `plugin` jobs) |

## Decision points

| Question | Decision | Why |
|---|---|---|
| Why both cosign signatures AND attest-build-provenance on the Go side? | **They answer different questions** | `cosign verify-blob` answers "was this archive signed by the connect-ktor release workflow at this tag" — a sigstore-TUF-rooted check that needs no GitHub-API access. `attest-build-provenance` answers "what was the build's full SLSA in-toto provenance" via GitHub's attestation store. The two are complementary and the cost of producing both is one extra step each. |
| Keyless (OIDC) vs key-based cosign signing? | **Keyless** | No long-lived secret to rotate or leak. The OIDC token is scoped to the workflow run; the resulting certificate's identity is the workflow file path + ref, which downstream `--certificate-identity-regexp` can pin precisely. Matches sigstore project recommendations. |
| Sign the Kotlin library JAR with cosign too? | **No** | The Maven Central artifact already carries a GPG signature, and Sonatype validates it on publish. Adding a cosign signature on the JAR uploaded to the GitHub Release would create two divergent verification surfaces (consumers pull JAR from Maven Central, not the Release). SLSA attestation on the JAR is the lightweight addition that aligns with GitHub's native attestations UI. |
| Attest the JAR before or after Maven Central publish? | **Before publish** | The attestation is keyed off the JAR's bytes. Attesting before publish keeps the JAR file path stable (`library/build/libs/*.jar` after `task build`) and ensures the same bytes Maven Central receives are the bytes recorded in the attestation. |
| Attestation glob on the Go side? | **`dist/*.tar.gz` + `dist/*.zip`** | These are the consumer-facing assets; the binaries inside the archives derive their identity from the archive hash. Cosign side-products (`.sig`, `.pem`) and SBOMs (`.cdx.sbom.json`) are intentionally excluded — attesting a signature would be circular, and the SBOMs are already linked to the archives by filename convention. |
| `release.draft: true` interaction with attestations? | **Safe** | `actions/attest-build-provenance` writes to GitHub's attestation store, not to the Release's asset list, so it works the same whether the Release is draft or published. The Release-asset SBOM upload from #210 still depends on the draft existing, which is why the `library` job retains `needs: plugin`. |
| `certificate-identity-regexp` strictness? | **Anchored to `release.yml@refs/tags/v.*`** | Strict enough to reject any other workflow in the repo (`ci.yml`, `codeql.yml`, etc.) or any non-tag ref, but flexible across version tags. README documents the exact pattern so consumers don't have to reverse-engineer it. |

## Commits

| Commit | Purpose |
|---|---|
| `252db78 release: sign Go artifacts with cosign and add SLSA provenance` | Add cosign `signs:` to GoReleaser, wire `actions/attest-build-provenance` into both jobs, broaden job permissions, install cosign, and document verification in README. |

## Test plan

- [x] `yq -e .` parses `release.yml` and `.goreleaser.yaml` cleanly.
- [x] `zizmor .github/workflows/release.yml` — no findings (10 suppressed are pre-existing).
- [ ] Next release tag push:
  - `plugin` job's cosign produces `dist/<archive>.sig` + `.pem` per archive, uploaded as Release assets next to the archives and SBOMs.
  - Both jobs produce attestations visible under the repo's "Attestations" tab.
  - `cosign verify-blob` against a downloaded archive succeeds with the documented identity regex.
  - `gh attestation verify` against a downloaded JAR and a downloaded archive both succeed.
- [ ] `slsa-verifier verify-artifact dist/<archive> --provenance-path <attestation> --source-uri github.com/ichizero/connect-ktor` succeeds (sanity check that the attestation is SLSA-shaped, not just GitHub-shaped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added instructions for verifying release artifacts, including steps to verify signatures using keyless signing and validate SLSA build provenance.

* **Chores**
  * Enhanced release workflow to generate and attach SLSA build provenance attestations for distributed artifacts.
  * Configured artifact signing for all releases to ensure integrity and authenticity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ichizero/connect-ktor/pull/211?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->