### PR TITLE
ci: integrate detekt, golangci-lint, govulncheck, and lefthook into the lint pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,24 +81,36 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: main # For spotless ratchet feature
+          fetch-depth: 0 # spotless ratchetFrom("origin/main") needs main reachable
           persist-credentials: false
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-      - uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
       - uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
         with:
           distribution: temurin
           java-version: 21
           cache: gradle
+
+      - name: Run Kotlin lints (spotless + detekt)
+        run: ./gradlew spotlessCheck detekt
+
+  lint-go:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: "./protoc-gen-connect-ktor/go.mod"
           cache-dependency-path: "./protoc-gen-connect-ktor/go.sum"
-      - uses: bufbuild/buf-setup-action@a47c93e0b1648d5651a065437926377d060baa99 # v1.50.0
-        with:
-          github_token: ${{ github.token }}
 
-      - name: Run lints
-        run: task lint
+      - uses: golangci/golangci-lint-action@db582008a42febd596419635a5abc9d9815daa9c # v9.2.1
+        with:
+          version: latest
+          working-directory: protoc-gen-connect-ktor
+
+      - uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
+        with:
+          go-version-input: ""
+          go-version-file: protoc-gen-connect-ktor/go.mod
+          work-dir: protoc-gen-connect-ktor

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
           go-version-file: "./protoc-gen-connect-ktor/go.mod"
           cache-dependency-path: "./protoc-gen-connect-ktor/go.sum"
 
-      - uses: golangci/golangci-lint-action@db582008a42febd596419635a5abc9d9815daa9c # v9.2.1
+      - uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:
           version: latest
           working-directory: protoc-gen-connect-ktor

--- a/README.md
+++ b/README.md
@@ -296,6 +296,22 @@ fun main() {
 }
 ```
 
+## Local development
+
+This repository ships a [lefthook](https://github.com/evilmartians/lefthook)
+configuration (`lefthook.yml`) that wires fast quality gates into
+`pre-commit`. Install it once per clone:
+
+```bash
+brew install lefthook
+lefthook install
+```
+
+The hooks run Spotless (ktlint), detekt, `go vet`, and golangci-lint on
+staged files. They are convenience-only — CI re-runs the same checks —
+so a commit can still be made with `LEFTHOOK=0 git commit ...` when
+needed.
+
 ## Verifying release artifacts
 
 Releases for the `protoc-gen-connect-ktor` Go binaries and the `library` JARs publish supply-chain

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -13,7 +13,7 @@ includes:
 tasks:
   lint:
     cmds:
-      - ./gradlew spotlessKotlinCheck
+      - ./gradlew spotlessCheck detekt
       - task: plugin:lint
   build:
     cmds:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,7 @@ buildscript {
         classpath(libs.maven.plugin)
         classpath(libs.kotlin.plugin)
         classpath(libs.spotless)
+        classpath(libs.detekt.plugin)
     }
     repositories {
         mavenCentral()
@@ -50,6 +51,32 @@ allprojects {
             )
             target("**/*.kts")
         }
+    }
+
+    apply(plugin = "io.gitlab.arturbosch.detekt")
+    extensions.configure<io.gitlab.arturbosch.detekt.extensions.DetektExtension> {
+        buildUponDefaultConfig = true
+        allRules = false
+        config.setFrom(files("$rootDir/config/detekt/detekt.yml"))
+        baseline = file("detekt-baseline.xml")
+        source.setFrom(
+            files(
+                "src/main/kotlin",
+                "src/test/kotlin",
+            ),
+        )
+    }
+    tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
+        jvmTarget = "21"
+        reports {
+            html.required.set(true)
+            xml.required.set(true)
+            sarif.required.set(false)
+            md.required.set(false)
+        }
+    }
+    tasks.withType<io.gitlab.arturbosch.detekt.DetektCreateBaselineTask>().configureEach {
+        jvmTarget = "21"
     }
 
     tasks.withType<Test> {

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -1,0 +1,52 @@
+# detekt configuration for connect-ktor.
+#
+# Inherits the default rule set; only deltas relative to the upstream
+# defaults are listed below. Anything you would otherwise place in a
+# baseline that represents a deliberate project-wide allowance should
+# go here instead, so the baselines stay reserved for legitimate
+# legacy debt that is being fixed over time.
+
+style:
+  # ktor / kotest / kotlinx.coroutines expose large, DSL-shaped APIs
+  # that are conventionally pulled in with a single wildcard import.
+  # Forcing per-symbol imports there hurts readability without
+  # buying any safety.
+  WildcardImport:
+    active: true
+    excludeImports:
+      - "io.kotest.*"
+      - "io.ktor.*"
+      - "kotlinx.coroutines.*"
+
+  # The conformance harness is internal test infra (CLI arg parsers and
+  # similar plumbing), not a public library surface. Multiple early
+  # returns are an idiomatic shape there.
+  ReturnCount:
+    active: true
+    excludes:
+      - "**/src/test/**"
+      - "**/src/testFixtures/**"
+      - "**/conformance/**"
+
+  # MagicNumber on test sources is mostly fixture data; the same goes
+  # for the conformance harness which encodes TLS record bytes and
+  # other protocol constants inline.
+  MagicNumber:
+    active: true
+    excludes:
+      - "**/src/test/**"
+      - "**/src/testFixtures/**"
+      - "**/conformance/**"
+
+exceptions:
+  # Test code and the conformance harness routinely catch a broad
+  # Throwable / Exception to reflect arbitrary handler failures back
+  # to the test framework or the conformance runner. Production code
+  # is still expected to catch specific exceptions.
+  TooGenericExceptionCaught:
+    active: true
+    excludes:
+      - "**/src/test/**"
+      - "**/src/testFixtures/**"
+      - "**/conformance/**"
+

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ kotlinx-serialization = "1.11.0"
 maven-publish = "0.37.0"
 spotless = "8.7.0"
 cyclonedx = "3.2.4"
+detekt = "1.23.8"
 
 connect = "0.9.0"
 ktor = "3.5.1"
@@ -22,6 +23,7 @@ kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 cyclonedx-bom = { id = "org.cyclonedx.bom", version.ref = "cyclonedx" }
+detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 
 [libraries]
 kotlin-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
@@ -58,6 +60,7 @@ kotlinx-serialization = { module = "org.jetbrains.kotlinx:kotlinx-serialization-
 
 maven-plugin = { module = "com.vanniktech:gradle-maven-publish-plugin", version.ref = "maven-publish" }
 spotless = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless" }
+detekt-plugin = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version.ref = "detekt" }
 
 [bundles]
 connect = [

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,32 @@
+# lefthook configuration for connect-ktor.
+#
+# Install lefthook locally and enable the hooks:
+#
+#     brew install lefthook
+#     lefthook install
+#
+# The pre-commit pipeline runs fast local quality gates. CI re-runs the
+# same checks, so these hooks are convenience-only and can be skipped
+# with `LEFTHOOK=0 git commit` if needed.
+
+pre-commit:
+  parallel: true
+  commands:
+    # Kotlin: run Spotless (ktlint) and detekt in a single Gradle
+    # invocation so the JVM only starts once per commit.
+    gradle-quality:
+      glob: "*.{kt,kts}"
+      run: ./gradlew --no-daemon spotlessCheck detekt
+
+    # Go: golangci-lint v2 already runs `govet` internally, so we
+    # don't duplicate it here. Falls back to a no-op when the binary
+    # is not installed locally (CI still runs it).
+    golangci:
+      root: "protoc-gen-connect-ktor/"
+      glob: "*.go"
+      run: |
+        if command -v golangci-lint >/dev/null 2>&1; then
+          golangci-lint run
+        else
+          echo "golangci-lint not installed locally; skipping (CI will run it)."
+        fi

--- a/library/detekt-baseline.xml
+++ b/library/detekt-baseline.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>CyclomaticComplexMethod:ErrorCodes.kt$fun Code.asHTTPStatusCode(): HttpStatusCode</ID>
+    <ID>LongMethod:HandleClientStream.kt$@PublishedApi internal suspend fun &lt;Req : Any, Res : Any&gt; handleClientStreamCall( call: ApplicationCall, maxMessageSize: Int, reqClass: KClass&lt;Req&gt;, resClass: KClass&lt;Res&gt;, handlerFunc: suspend (Flow&lt;Req&gt;, ApplicationCall) -&gt; ResponseMessage&lt;Res&gt;, )</ID>
+    <ID>MagicNumber:EnvelopeFrameReader.kt$0xFF</ID>
+    <ID>MagicNumber:EnvelopeFrameReader.kt$16</ID>
+    <ID>MagicNumber:EnvelopeFrameReader.kt$24</ID>
+    <ID>MagicNumber:EnvelopeFrameReader.kt$3</ID>
+    <ID>MagicNumber:EnvelopeFrameReader.kt$4</ID>
+    <ID>MagicNumber:EnvelopeFrameReader.kt$8</ID>
+    <ID>MagicNumber:EnvelopeFrameWriter.kt$0xFF</ID>
+    <ID>MagicNumber:EnvelopeFrameWriter.kt$16</ID>
+    <ID>MagicNumber:EnvelopeFrameWriter.kt$24</ID>
+    <ID>MagicNumber:EnvelopeFrameWriter.kt$3</ID>
+    <ID>MagicNumber:EnvelopeFrameWriter.kt$4</ID>
+    <ID>MagicNumber:EnvelopeFrameWriter.kt$8</ID>
+    <ID>MatchingDeclarationName:Configuration.kt$ConnectContentType</ID>
+    <ID>MaxLineLength:ErrorPayload.kt$*</ID>
+    <ID>ThrowsCount:HandleClientStream.kt$@PublishedApi internal suspend fun &lt;Req : Any, Res : Any&gt; handleClientStreamCall( call: ApplicationCall, maxMessageSize: Int, reqClass: KClass&lt;Req&gt;, resClass: KClass&lt;Res&gt;, handlerFunc: suspend (Flow&lt;Req&gt;, ApplicationCall) -&gt; ResponseMessage&lt;Res&gt;, )</ID>
+    <ID>TooGenericExceptionCaught:HandleClientStream.kt$e: Throwable</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/protoc-gen-connect-ktor/.golangci.yml
+++ b/protoc-gen-connect-ktor/.golangci.yml
@@ -1,0 +1,20 @@
+version: "2"
+
+run:
+  timeout: 5m
+
+linters:
+  default: none
+  enable:
+    - bodyclose
+    - errcheck
+    - gosec
+    - govet
+    - ineffassign
+    - revive
+    - staticcheck
+
+formatters:
+  enable:
+    - gofmt
+    - goimports

--- a/protoc-gen-connect-ktor/cmd/protoc-gen-connect-ktor/main.go
+++ b/protoc-gen-connect-ktor/cmd/protoc-gen-connect-ktor/main.go
@@ -1,3 +1,5 @@
+// Binary protoc-gen-connect-ktor is a protoc plugin that emits Ktor route
+// handler interfaces from Protocol Buffers service definitions.
 package main
 
 import (

--- a/protoc-gen-connect-ktor/generator.go
+++ b/protoc-gen-connect-ktor/generator.go
@@ -1,3 +1,5 @@
+// Package generator implements the protoc plugin entry point that emits
+// Ktor route handler interfaces from Protocol Buffers service definitions.
 package generator
 
 import (
@@ -18,6 +20,8 @@ const (
 	streamTypeClient streamType = "Client"
 )
 
+// Run is the protogen entry point: it iterates the files marked for
+// generation by protoc and emits one Ktor handler file per input.
 func Run(plugin *protogen.Plugin) error {
 	for _, file := range plugin.Files {
 		if !file.Generate {

--- a/protoc-gen-connect-ktor/internal/protogenhelper/run.go
+++ b/protoc-gen-connect-ktor/internal/protogenhelper/run.go
@@ -1,3 +1,6 @@
+// Package protogenhelper wraps protoc plugin boilerplate (request decode,
+// dummy go_package injection, response marshalling) so generators only need
+// to provide the actual code-emit callback.
 package protogenhelper
 
 import (
@@ -10,6 +13,9 @@ import (
 	"google.golang.org/protobuf/types/pluginpb"
 )
 
+// Run reads a CodeGeneratorRequest from stdin, dispatches it to generator,
+// and writes the CodeGeneratorResponse to stdout. It is the canonical main
+// for a protoc plugin built on top of [protogen].
 func Run(opts *protogen.Options, generator func(*protogen.Plugin) error) error {
 	if len(os.Args) > 1 {
 		return fmt.Errorf("unknown argument %q", os.Args[1])

--- a/protoc-gen-connect-ktor/internal/tmplfunc/tmplfunc.go
+++ b/protoc-gen-connect-ktor/internal/tmplfunc/tmplfunc.go
@@ -1,3 +1,5 @@
+// Package tmplfunc provides the template.FuncMap used by the protoc plugin
+// templates for case manipulation and indentation helpers.
 package tmplfunc
 
 import (
@@ -5,6 +7,7 @@ import (
 	"text/template"
 )
 
+// Map is the FuncMap bound into every template the plugin renders.
 var Map = template.FuncMap{
 	"toLowerFirst": toLowerFirst,
 	"indent":       indent,
@@ -20,7 +23,7 @@ func toLowerFirst(value string) string {
 
 func indent(spaces int, value string) string {
 	padding := strings.Repeat(" ", spaces)
-	return padding + strings.Replace(value, "\n", "\n"+padding, -1)
+	return padding + strings.ReplaceAll(value, "\n", "\n"+padding)
 }
 
 func nIndent(spaces int, value string) string {


### PR DESCRIPTION
## Summary

Wires three new static-analysis tools into CI — detekt for Kotlin, golangci-lint and govulncheck for the Go plugin — and exposes the same checks locally via [lefthook](https://github.com/evilmartians/lefthook) pre-commit hooks.

`connect-ktor` already runs Spotless (ktlint) in CI and CodeQL on a schedule, but everything between formatting and CVE scanning is unchecked: Kotlin code style anti-patterns, common Go bugs, and known-vulnerable Go transitive deps would all reach `main` today. This PR closes that gap with a single shared rule overlay so the baselines only contain genuine debt and the local hooks mirror exactly what CI runs.

This is PR4 of the security blueprint series (PR1 = repo hygiene, PR5 / PR6 = SBOM + signing already merged).

## What changed

### CI structure: 4 lint jobs collapse to 2

The four candidate jobs (`lint`, `detekt`, `golangci-lint`, `govulncheck`) are consolidated by language:

- **`lint`**: Kotlin-only. Runs `./gradlew spotlessCheck detekt` in a single Gradle invocation so the JVM starts once and the Gradle daemon is shared between the two tasks. The previous double `actions/checkout` (one for `main`, one for the PR head, needed by `spotless.ratchetFrom("origin/main")`) is replaced with a single `fetch-depth: 0` checkout.
- **`lint-go`**: Go-only. Runs `golangci/golangci-lint-action@v9.2.1` followed by `golang/govulncheck-action@v1.0.4`, both scoped to `protoc-gen-connect-ktor/`. Standalone `go vet` is dropped because golangci-lint v2 already runs `govet` as a built-in linter.

This trades ~10s of wall-clock for ~95s of runner minutes per CI run, because the `test` (~105s) and `conformance` (~99s) jobs remain on the critical path either way.

### detekt configuration: shared overlay so baselines stay meaningful

`config/detekt/detekt.yml` is a small overlay on top of the default ruleset:

- `WildcardImport.excludeImports`: `io.kotest.*`, `io.ktor.*`, `kotlinx.coroutines.*` — these expose DSL-shaped APIs where a single wildcard is the idiomatic spelling in both `main/` and `test/`.
- `MagicNumber.excludes`, `TooGenericExceptionCaught.excludes`, `ReturnCount.excludes`: `**/src/test/**`, `**/src/testFixtures/**`, `**/conformance/**`. The conformance module is internal cross-engine test infra, not a public library surface, so the strictness those rules enforce for production code is misplaced there.

With the overlay applied, `library/detekt-baseline.xml` shrinks from 59 entries (56 of which were `WildcardImport`) to 18 entries; `conformance/detekt-baseline.xml` becomes empty and is removed.

The remaining 18 entries are real cleanup items in the streaming code added by PR #192. They are baselined here rather than blocking this PR — see "Follow-ups" below.

### golangci-lint v2: opinionated minimum set + fixes for the 7 surfaced findings

`protoc-gen-connect-ktor/.golangci.yml` enables `govet`, `staticcheck`, `revive`, `ineffassign`, `bodyclose`, `errcheck`, and `gosec` on top of `default: none`. Running it locally surfaced seven findings, all in `protoc-gen-connect-ktor/`:

- six missing godoc comments on packages / exported declarations (`revive:package-comments`, `revive:exported`)
- one `strings.Replace(s, old, new, -1)` that `staticcheck:QF1004` rewrites as `strings.ReplaceAll(s, old, new)`

All seven are fixed in this PR. govulncheck reports 0 known CVEs on the current `go.mod`.

### lefthook: same checks, locally, in two parallel hooks

`lefthook.yml` runs:

- `gradle-quality`: `./gradlew --no-daemon spotlessCheck detekt` — Kotlin Spotless + detekt in one Gradle invocation, JVM started once per commit.
- `golangci`: `golangci-lint run`, gated on the binary being installed locally so contributors who haven't picked it up yet still get a smooth commit experience (CI is the authoritative gate).

Bypassable with `LEFTHOOK=0 git commit ...`. README ships a "Local development" section with the `brew install lefthook && lefthook install` bootstrap.

### Action SHAs added

| Action | Version | SHA |
|---|---|---|
| `golangci/golangci-lint-action` | v9.2.1 | `db582008…` |
| `golang/govulncheck-action` | v1.0.4 | `b625fbe0…` |

## Decision points

| Question | Decision | Why |
|---|---|---|
| One lint job per tool, or per language? | **Per language** (`lint` + `lint-go`) | The four candidate jobs would each repeat `setup-java` or `setup-go` (~30s of runner time each). Per language collapses that to two and lets Spotless+detekt share a Gradle daemon. Wall-clock barely changes because `test`/`conformance` is the critical path either way. |
| `go vet` step in CI? | **Dropped** | golangci-lint v2 runs the `govet` linter as a built-in; an explicit step would only be duplicate work and a second source of truth. |
| Address the 18 remaining baseline entries in this PR? | **No — baseline + follow-up issues** | They are real cleanup items, but the streaming code they target landed in PR #192 and addressing them properly (e.g. `CancellationException` re-throw, function decomposition, named protocol constants) is its own design conversation. Baselining keeps this PR focused on lint *plumbing*. |
| WildcardImport pattern: `io.kotest.**` or `io.kotest.*`? | **`io.kotest.*`** | detekt's `excludeImports` matches against the full import path (e.g. `io.kotest.assertions.json.*`). The single-star pattern matches that; the double-star did not (verified locally — baseline still contained 54 `WildcardImport` entries until switched to `*`). |
| Detekt config baseline scope: per-rule `excludes` vs separate test config file? | **Per-rule `excludes` in one config** | Two separate detekt tasks per module would double the configuration surface and the CI wall-clock for marginal gain. One config with per-rule path globs is enough to differentiate production-code strictness from test/conformance leniency. |
| `task lint` should include detekt locally? | **Yes** | The Taskfile's `lint` target is the canonical "run all linters" entry point; keeping it in sync with CI prevents the "passed locally, failed in CI" footgun. Switched from `spotlessKotlinCheck` to `spotlessCheck` so `*.kts` files are also covered (parity with CI). |
| lefthook parallelism + Gradle daemon? | **Single Gradle hook, parallel-safe** | Two parallel Gradle hooks (one for Spotless, one for detekt) would race for the daemon and double JVM startup cost on every commit. Merging them into one `gradle-quality` hook avoids both. |
| Local `golangci-lint` not installed → fail or skip? | **Skip with a log line** | Hard failure would block commits on freshly cloned machines; CI re-runs the same check authoritatively. The skip is documented in the hook itself and in the README's "Local development" section. |

## Commits

| Commit | Purpose |
|---|---|
| `e30414c ci: add Kotlin (detekt) and Go (golangci-lint, govulncheck) lints` | Detekt plugin + shared config, slimmed baseline, golangci-lint v2 config, govulncheck job, CI restructure (4→2 jobs), Taskfile alignment, godoc + `strings.ReplaceAll` fixes surfaced by golangci-lint. |
| `583d0bb chore(dev): add lefthook pre-commit pipeline mirroring CI lint jobs` | `lefthook.yml` (gradle-quality + golangci, parallel) and README "Local development" section. |

## Test plan

- [x] `./gradlew spotlessCheck detekt` passes locally (library + conformance).
- [x] `./gradlew :library:detekt` and `./gradlew :conformance:detekt` independently pass.
- [x] `cd protoc-gen-connect-ktor && golangci-lint run --timeout=5m ./...` reports **0 issues** with the new config.
- [x] `cd protoc-gen-connect-ktor && govulncheck ./...` reports **0 vulnerabilities**.
- [x] `task lint` (root Taskfile) runs the same checks locally.
- [ ] CI: both `lint` and `lint-go` jobs pass on this PR; ratchet behaviour preserved (no false positives on unchanged files).
- [ ] CI: `permissions: contents: read` enforced on both new jobs (zizmor will catch regressions).

## Follow-ups (not blocking this PR)

The 18 baselined entries in `library/detekt-baseline.xml` are real cleanup items in the streaming code from PR #192. Tracking each as its own issue rather than expanding this PR:

1. `HandleClientStream.kt` — `catch (Throwable)` in suspending code suppresses `CancellationException` propagation (matches the project's existing memory note on coroutine cancellation). Switch to specific exceptions + explicit `CancellationException` re-throw.
2. Same file — `LongMethod` / `CyclomaticComplexMethod` / `ThrowsCount` are all concentrated in `handleClientStreamCall`; resolve via function decomposition.
3. `EnvelopeFrame{Reader,Writer}.kt` — twelve `MagicNumber` entries on protocol byte offsets; replace with named constants.
4. `Configuration.kt` — `MatchingDeclarationName:ConnectContentType` is a single-declaration-vs-filename mismatch; either rename the file or split the declaration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)