### PR TITLE
docs(security): add security policy, CODEOWNERS, FUNDING, and PR template

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,29 @@
+# Code owners for this repository.
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+#
+# Most-specific rule wins. CODEOWNERS is used here as an *auto-reviewer
+# assignment* layer, not as a hard merge gate — branch protection does
+# not require code-owner approval, so Dependabot's minor/patch
+# auto-merge flow stays untouched.
+
+# Default — anything not matched by a more specific rule.
+*                              @ichizero
+
+# Module owners (kept explicit so future co-maintainers can be slotted
+# in per-module without touching the default rule).
+/library/                      @ichizero
+/protoc-gen-connect-ktor/      @ichizero
+/conformance/                  @ichizero
+
+# Security- and supply-chain-critical files: changes here should always
+# go past the repository owner even if module-level ownership is later
+# delegated.
+/.github/                      @ichizero
+/.github/CODEOWNERS            @ichizero
+/.github/FUNDING.yml           @ichizero
+/.github/workflows/            @ichizero
+/SECURITY.md                   @ichizero
+/LICENSE                       @ichizero
+/.goreleaser.yaml              @ichizero
+/lefthook.yml                  @ichizero
+/gradle/libs.versions.toml     @ichizero

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# Funding sources surfaced on the repository's "Sponsor" button.
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
+github: ichizero

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,65 @@
+<!--
+Reference the relevant issue with "Closes #N" on the first line if applicable.
+Drop any section that does not apply. Keep tables for two or more rows;
+inline a single bullet otherwise.
+-->
+
+## Summary
+
+<!--
+2–6 sentences. Lead with what changes for users / downstream callers,
+then why this change is needed (the problem, the constraint, the
+motivating use case). Avoid restating the diff — that goes below.
+Mention stacked / dependent PRs at the end.
+-->
+
+## What changed
+
+<!--
+Bulleted, file-grouped overview. One sub-bullet per non-obvious change.
+Prefer code-fenced identifiers (`functionName`, `path/to/file.kt`) so
+reviewers can grep. Include behavioural details, not just file names.
+-->
+
+-
+
+## Decision points
+
+<!--
+For each non-obvious choice in this PR, capture the question that came
+up, the decision, and the reason. This is where reviewers learn *why*
+the diff looks the way it does, and where future maintainers learn
+which branches of the design tree were considered. Skip the table if
+nothing was contested.
+
+Example row:
+| Why pin actions to commit SHA, not tag? | Tag-based pins can be moved silently | A compromised tag could redirect to a malicious commit; SHA pins are immutable. |
+-->
+
+| Question | Decision | Why |
+|---|---|---|
+
+## Commits
+
+<!--
+One row per commit on the branch, in topological order. Helps reviewers
+read the PR commit-by-commit when the diff is large.
+
+Example row:
+| `abc1234 fix(api): reject empty Authorization headers` | Closes the auth-bypass path from #456. |
+-->
+
+| Commit | Purpose |
+|---|---|
+
+## Test plan
+
+<!--
+Checklist of verifications. Use [x] for things already done locally and
+[ ] for things that only run in CI or post-merge (release tag push,
+production deploy, scanner ingestion, etc.). Be specific — "tests pass"
+is not a test plan; "./gradlew :library:test passes 60 tests including
+new streaming framing coverage" is.
+-->
+
+- [ ]

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,45 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest release of connect-ktor is supported. When a vulnerability
+is fixed, the fix ships in the next patch release; older releases are not
+back-patched. Users are expected to upgrade to the latest release to pick
+up security fixes.
+
+| Version         | Supported          |
+| --------------- | ------------------ |
+| Latest release  | :white_check_mark: |
+| Older releases  | :x:                |
+
+## Reporting a Vulnerability
+
+Please report suspected vulnerabilities **privately** via GitHub's
+[Private Vulnerability Reporting](https://github.com/ichizero/connect-ktor/security/advisories/new)
+on this repository. Do **not** open a public issue, pull request, or
+discussion for security-sensitive reports.
+
+When filing a report, include as much of the following as you can:
+
+- A description of the issue and its potential impact.
+- The affected version(s) and configuration (Ktor engine, JDK, OS).
+- Reproduction steps or a proof-of-concept.
+- Any known mitigations or workarounds.
+
+## Disclosure Process and Timelines
+
+connect-ktor is maintained on a best-effort basis by a single
+maintainer. The targets below reflect that and may slip for reports
+that arrive during travel or other extended outages.
+
+- **Acknowledgement: within 7 days** (best effort) of receiving the
+  report.
+- **Status updates: at least every 30 days** while the report is open.
+- **Disclosure: within 90 days** of the initial report. We will work
+  with the reporter to release a fix and publish a GitHub Security
+  Advisory before this deadline whenever possible. If a fix is not
+  feasible within this window, we will coordinate an extension with
+  the reporter.
+
+Credit will be given to reporters in the published advisory unless they
+prefer to remain anonymous.


### PR DESCRIPTION
## Summary

Adds the repository-level scaffolding pieces that GitHub looks for to drive its security, sponsorship, and review UX: a vulnerability disclosure policy (`SECURITY.md`), a code-owner map (`.github/CODEOWNERS`), a sponsorship config (`.github/FUNDING.yml`), and the structured pull-request template the project has been using on PRs #192, #210, #211, and #234.

Why now: the SBOM / signing / SLSA work (PRs #210, #211, #234) put the supply-chain side of the security posture in place, but there is no documented intake path for vulnerability reports, no auto-reviewer assignment, and no codified PR shape for future contributors. This PR closes those gaps without changing any runtime behaviour.

This is PR1 of the security blueprint series — the smallest, lowest-risk piece, kept in its own PR so reviewers can read the policies without churn from CI / build changes.

## What changed

- **`SECURITY.md`** — Private Vulnerability Reporting flow (rather than email), with explicit timeline targets (7-day acknowledgement on a best-effort basis, status updates at least every 30 days, disclosure within 90 days) and a Supported Versions matrix that says "latest release only, fixes ship as the next patch." A "single maintainer, best effort" sentence keeps the timeline honest.
- **`.github/CODEOWNERS`** — Default rule `* @ichizero`, plus explicit per-module rules (`/library/`, `/protoc-gen-connect-ktor/`, `/conformance/`) and explicit owner-required paths for security- and supply-chain-critical files (`/.github/`, `/.github/CODEOWNERS`, `/.github/FUNDING.yml`, `/.github/workflows/`, `/SECURITY.md`, `/LICENSE`, `/.goreleaser.yaml`, `/lefthook.yml`, `/gradle/libs.versions.toml`). The leading comment is explicit that this layer is for *auto-reviewer assignment*, not a hard merge gate, so Dependabot's minor/patch auto-merge flow is untouched.
- **`.github/FUNDING.yml`** — Minimal GitHub Sponsors entry so the repo's "Sponsor" button surfaces. Easy to extend with other platforms later.
- **`.github/pull_request_template.md`** — Five sections (Summary, What changed, Decision points, Commits, Test plan) matching the de-facto style of the recent merged PRs. HTML comments inline the writing guidance so contributors can see it as they fill the template in; example rows live inside those HTML comments rather than the rendered tables so an empty PR doesn't ship placeholder rows.

## Decision points

| Question | Decision | Why |
|---|---|---|
| Should CODEOWNERS act as a hard merge gate? | **No, auto-reviewer only** | Branch protection does not require code-owner approval. Treating CODEOWNERS as a hard gate would break Dependabot's existing minor/patch auto-merge, which we want to keep. The file's leading comment makes this contract explicit so future maintainers don't enable code-owner enforcement without revisiting the auto-merge flow. |
| Why list both `/.github/` and `/.github/CODEOWNERS` (and `/.github/FUNDING.yml`, etc.)? | **Defence in depth** | Under "most-specific wins", the per-file rules are redundant *today* (same owner as `/.github/`). They become load-bearing the moment per-directory ownership is delegated to a future co-maintainer — at which point CODEOWNERS itself, the funding config, the workflows, etc. should still require the original owner. |
| Disclosure SLA shape? | **7 days ack (best effort) / 30 days updates / 90 days disclosure** | The 90-day cap aligns with GitHub Security Advisory's default and the broader CVE coordination norm. 7d ack is realistic for a single-maintainer project; the original draft used 72h, which would have been over-promised. |
| Supported Versions matrix wording? | **"Latest release only, fixes ship as the next patch"** | Surveyed `syft`, `goreleaser`, `lefthook`, `spf13/cobra`, and JetBrains/kotlin policies. Most small-to-mid OSS projects either pin to "latest release" or "latest major"; a personal library does not have the maintenance bandwidth to back-port. Wording avoids the literal `MAJOR.MINOR` notation so it stays readable. |
| PR template — placeholder rows in the rendered tables? | **No, keep examples in HTML comments** | A PR opened from the template would otherwise contain literal `\| owner/action \| v1.2.3 \| abc1234… \|` rows that reviewers would have to delete. HTML-commented example rows give contributors the shape without polluting the rendered diff. |
| PR template — keep the "Action SHAs added" subsection? | **Dropped** | The series of merged PRs that produced this template style (SBOM / signing / cosign) each had a different set of pinned actions to list; bolting that into the canonical template suggested every PR would touch GitHub Actions, which is misleading. Contributors who add actions can still add a one-off table under "What changed". |
| FUNDING entry — `github_sponsors` only? | **Yes, `github: ichizero`** | Single-platform start is enough to surface the Sponsor button on GitHub. Other platforms (ko-fi, buy_me_a_coffee, opencollective, etc.) can be added incrementally if usage grows; an empty file would surface nothing. |

## Commits

| Commit | Purpose |
|---|---|
| `9675d0f docs(security): add security policy, CODEOWNERS, and PR template` | Adds `SECURITY.md`, `.github/CODEOWNERS`, `.github/FUNDING.yml`, and `.github/pull_request_template.md`. Commit subject predates the FUNDING.yml addition; kept singular to avoid a noisy amend chain on a docs-only branch. |

## Test plan

- [x] `gh api -X GET https://api.github.com/repos/ichizero/connect-ktor/security/advisories/new` resolves (URL referenced in `SECURITY.md` is reachable).
- [x] `.github/CODEOWNERS` parses against GitHub's spec — `* @ichizero` default rule plus most-specific path rules, matching the [docs example](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file).
- [x] `.github/FUNDING.yml` follows the [supported keys schema](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository) (`github:` only).
- [x] PR template renders the five sections cleanly when opening a PR through the GitHub UI (HTML comments hidden; tables empty so reviewers see the structural shape without fake rows).
- [ ] After merge: confirm the "Sponsor" button appears on the repo home; confirm GitHub auto-requests `@ichizero` as a reviewer on a fresh PR; confirm `SECURITY.md` triggers GitHub's "Security policy" badge on the Insights → Community Standards page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a structured pull request checklist to make submissions more consistent and easier to review.
  * Added a security policy detailing private vulnerability reporting, expected response cadence, and disclosure timelines.
* **Chores**
  * Added repository ownership rules to improve review routing using the most-specific match behavior.
  * Configured GitHub Sponsors information to surface sponsorship for the repository.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->