### PR TITLE
chore(deps): group github/codeql-action dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      codeql-action:
+        patterns:
+          - "github/codeql-action/*"
   - package-ecosystem: "gradle"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Summary
- `github/codeql-action` の init / analyze / upload-sarif が個別の Dependabot PR (#248, #249, #250) に分かれてしまっていたため、`.github/dependabot.yml` の `github-actions` エコシステムに `groups` 設定を追加し、`github/codeql-action/*` をまとめて1つの PR で更新されるようにした。

## Test plan
- [ ] Dependabot の次回実行で `github/codeql-action/*` の更新が単一 PR にまとまることを確認する

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Grouped CodeQL Action updates together for more streamlined maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->