### PR TITLE
chore(deps): add 7-day cooldown to dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
     groups:
       codeql-action:
         patterns:
@@ -12,7 +14,11 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "gomod"
     directory: "./protoc-gen-connect-ktor"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## Background & Rationale

GitHub Dependabot opens an update PR as soon as a new version of a dependency is released. But new releases sometimes turn out to have bugs shortly after release and get quickly patched or reverted, so following them immediately carries the risk of pulling in an unstable version.

GitHub Dependabot has a [`cooldown`](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown) setting (added in late 2024) built specifically to address this. It makes Dependabot wait for a set period after a new package version is published before opening an update PR for it.

## Changes

Added `cooldown.default-days: 7` to each of the three `updates` entries in `.github/dependabot.yml` (`github-actions` / `gradle` / `gomod`):

```yaml
cooldown:
  default-days: 7
```

- `cooldown` also supports per-version-type settings via `semver-major-days` / `semver-minor-days` / `semver-patch-days`, and per-package control via `include` / `exclude`, but this change keeps it simple with a uniform `default-days: 7` across the board. Finer-grained tuning can be added later if needed.
- The existing `schedule` (daily), `groups` (codeql-action grouping), and `directory` settings are unchanged.

## Rationale for the value chosen

- Explicitly setting 7 days instead of the default (3 days) ensures a full week of buffer even across a weekend.
- Applying it uniformly across all ecosystems keeps the configuration simple while still avoiding unstable dependency updates right after release.

## Verification

- Confirmed the YAML is valid via `python3 -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"`
- Confirmed via `git diff` that no changes beyond adding the cooldown setting are included

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted automated dependency update scheduling to space out updates by seven days across supported build and automation ecosystems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->