### PR TITLE
docs: backfill CHANGELOG and add dependabot tegami entry

### DIFF
--- a/.tegami/2026-08-02-dependencies.md
+++ b/.tegami/2026-08-02-dependencies.md
@@ -1,0 +1,36 @@
+---
+packages:
+    connect-ktor: patch
+---
+
+## Dependencies
+
+- chore(deps): Bump gradle-wrapper from 9.6.0 to 9.6.1 by @dependabot[bot] in [PR #239](https://github.com/ichizero/connect-ktor/pull/239)
+- chore(deps): Bump org.junit.jupiter:junit-jupiter-engine from 6.1.0 to 6.1.1 by @dependabot[bot] in [PR #238](https://github.com/ichizero/connect-ktor/pull/238)
+- chore(deps): Bump goreleaser/goreleaser-action from 7.2.2 to 7.2.3 by @dependabot[bot] in [PR #240](https://github.com/ichizero/connect-ktor/pull/240)
+- chore(deps): Bump golangci/golangci-lint-action from 9.2.1 to 9.3.0 by @dependabot[bot] in [PR #241](https://github.com/ichizero/connect-ktor/pull/241)
+- chore(deps): Bump github/codeql-action/upload-sarif from 4.36.2 to 4.36.3 by @dependabot[bot] in [PR #245](https://github.com/ichizero/connect-ktor/pull/245)
+- chore(deps): Bump arduino/setup-task from 2.0.0 to 3.0.0 by @dependabot[bot] in [PR #243](https://github.com/ichizero/connect-ktor/pull/243)
+- chore(deps): Bump github/codeql-action/init from 4.36.2 to 4.36.3 by @dependabot[bot] in [PR #246](https://github.com/ichizero/connect-ktor/pull/246)
+- chore(deps): Bump actions/attest-build-provenance from 4.1.0 to 4.1.1 by @dependabot[bot] in [PR #237](https://github.com/ichizero/connect-ktor/pull/237)
+- chore(deps): Bump spotless from 8.7.0 to 8.8.0 by @dependabot[bot] in [PR #242](https://github.com/ichizero/connect-ktor/pull/242)
+- chore(deps): Bump actions/setup-java from 5.4.0 to 5.5.0 by @dependabot[bot] in [PR #247](https://github.com/ichizero/connect-ktor/pull/247)
+- chore(deps): Bump golang/govulncheck-action from 1.0.4 to 1.1.0 by @dependabot[bot] in [PR #253](https://github.com/ichizero/connect-ktor/pull/253)
+- chore(deps): Bump org.junit.jupiter:junit-jupiter-engine from 6.1.1 to 6.1.2 by @dependabot[bot] in [PR #254](https://github.com/ichizero/connect-ktor/pull/254)
+- chore(deps): Bump the codeql-action group with 3 updates by @dependabot[bot] in [PR #252](https://github.com/ichizero/connect-ktor/pull/252)
+- chore(deps): Bump kotlin from 2.3.21 to 2.4.0 by @dependabot[bot] in [PR #216](https://github.com/ichizero/connect-ktor/pull/216)
+- chore(deps): Bump actions/setup-go from 6.5.0 to 7.0.0 by @dependabot[bot] in [PR #261](https://github.com/ichizero/connect-ktor/pull/261)
+- chore(deps): Bump actions/attest from 4.1.1 to 4.2.0 by @dependabot[bot] in [PR #260](https://github.com/ichizero/connect-ktor/pull/260)
+- chore(deps): Bump actions/setup-java from 5.5.0 to 5.6.0 by @dependabot[bot] in [PR #259](https://github.com/ichizero/connect-ktor/pull/259)
+- chore(deps): Bump the codeql-action group with 3 updates by @dependabot[bot] in [PR #258](https://github.com/ichizero/connect-ktor/pull/258)
+- chore(deps): Bump zizmorcore/zizmor-action from 0.5.7 to 0.6.0 by @dependabot[bot] in [PR #256](https://github.com/ichizero/connect-ktor/pull/256)
+- chore(deps): Bump org.cyclonedx.bom from 3.2.4 to 3.3.0 by @dependabot[bot] in [PR #257](https://github.com/ichizero/connect-ktor/pull/257)
+- chore(deps): Bump ossf/scorecard-action from 2.4.3 to 2.4.4 by @dependabot[bot] in [PR #266](https://github.com/ichizero/connect-ktor/pull/266)
+- chore(deps): Bump zizmorcore/zizmor-action from 0.6.0 to 0.6.1 by @dependabot[bot] in [PR #265](https://github.com/ichizero/connect-ktor/pull/265)
+- chore(deps): Bump com.squareup.okio:okio from 3.17.0 to 3.18.0 by @dependabot[bot] in [PR #264](https://github.com/ichizero/connect-ktor/pull/264)
+- chore(deps): Bump the codeql-action group with 3 updates by @dependabot[bot] in [PR #263](https://github.com/ichizero/connect-ktor/pull/263)
+- chore(deps): Bump actions/checkout from 7.0.0 to 7.0.1 by @dependabot[bot] in [PR #262](https://github.com/ichizero/connect-ktor/pull/262)
+- chore(deps): Bump the codeql-action group with 3 updates by @dependabot[bot] in [PR #271](https://github.com/ichizero/connect-ktor/pull/271)
+- chore(deps): Bump kotlin from 2.4.0 to 2.4.10 by @dependabot[bot] in [PR #255](https://github.com/ichizero/connect-ktor/pull/255)
+- chore(deps): Bump the docs-site group with 2 updates by @dependabot[bot] in [PR #273](https://github.com/ichizero/connect-ktor/pull/273)
+- chore(deps): Bump pnpm/action-setup from 4.2.0 to 6.0.9 by @dependabot[bot] in [PR #274](https://github.com/ichizero/connect-ktor/pull/274)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,322 @@
+## connect-ktor@0.2.0
+
+### Support Connect client-streaming RPCs (STREAM_TYPE_CLIENT_STREAM)
+
+connect-ktor now supports client-side streaming RPCs.
+
+[PR #192](https://github.com/ichizero/connect-ktor/pull/192)
+
+### Dependencies
+
+- chore(deps): Bump github/codeql-action from 4.35.5 to 4.36.0 by @dependabot[bot] in [PR #212](https://github.com/ichizero/connect-ktor/pull/212)
+- chore(deps): Bump spotless from 8.5.1 to 8.6.0 by @dependabot[bot] in [PR #213](https://github.com/ichizero/connect-ktor/pull/213)
+- chore(deps): Bump github/codeql-action from 4.36.0 to 4.36.1 by @dependabot[bot] in [PR #214](https://github.com/ichizero/connect-ktor/pull/214)
+- chore(deps): Bump github/codeql-action from 4.36.1 to 4.36.2 by @dependabot[bot] in [PR #217](https://github.com/ichizero/connect-ktor/pull/217)
+- chore(deps): Bump gradle/actions from 6.1.0 to 6.1.1 by @dependabot[bot] in [PR #219](https://github.com/ichizero/connect-ktor/pull/219)
+- chore(deps): Bump protobuf from 4.35.0 to 4.35.1 by @dependabot[bot] in [PR #220](https://github.com/ichizero/connect-ktor/pull/220)
+- chore(deps): Bump actions/checkout from 6.0.2 to 6.0.3 by @dependabot[bot] in [PR #215](https://github.com/ichizero/connect-ktor/pull/215)
+- chore(deps): Bump com.squareup.okhttp3:okhttp from 5.3.2 to 5.4.0 by @dependabot[bot] in [PR #218](https://github.com/ichizero/connect-ktor/pull/218)
+- chore(deps): Bump zizmorcore/zizmor-action from 0.5.6 to 0.5.7 by @dependabot[bot] in [PR #228](https://github.com/ichizero/connect-ktor/pull/228)
+- chore(deps): Bump com.vanniktech:gradle-maven-publish-plugin from 0.36.0 to 0.37.0 by @dependabot[bot] in [PR #227](https://github.com/ichizero/connect-ktor/pull/227)
+- chore(deps): Bump gradle-wrapper from 9.5.1 to 9.6.0 by @dependabot[bot] in [PR #226](https://github.com/ichizero/connect-ktor/pull/226)
+- chore(deps): Bump actions/checkout from 6.0.3 to 7.0.0 by @dependabot[bot] in [PR #225](https://github.com/ichizero/connect-ktor/pull/225)
+- chore(deps): Bump connect from 0.8.2 to 0.9.0 by @dependabot[bot] in [PR #222](https://github.com/ichizero/connect-ktor/pull/222)
+- chore(deps): Bump gradle/actions from 6.1.1 to 6.2.0 by @dependabot[bot] in [PR #221](https://github.com/ichizero/connect-ktor/pull/221)
+- chore(deps): Bump actions/setup-java from 5.2.0 to 5.3.0 by @dependabot[bot] in [PR #223](https://github.com/ichizero/connect-ktor/pull/223)
+- chore(deps): Bump spotless from 8.6.0 to 8.7.0 by @dependabot[bot] in [PR #224](https://github.com/ichizero/connect-ktor/pull/224)
+- chore(deps): Bump ktor from 3.5.0 to 3.5.1 by @dependabot[bot] in [PR #231](https://github.com/ichizero/connect-ktor/pull/231)
+- chore(deps): Bump actions/setup-java from 5.3.0 to 5.4.0 by @dependabot[bot] in [PR #230](https://github.com/ichizero/connect-ktor/pull/230)
+- chore(deps): Bump actions/setup-go from 6.4.0 to 6.5.0 by @dependabot[bot] in [PR #229](https://github.com/ichizero/connect-ktor/pull/229)
+
+## connect-ktor@0.1.11
+
+### Verify Connect protocol compliance against Ktor CIO and Netty
+
+[PR #185](https://github.com/ichizero/connect-ktor/pull/185)
+
+### Dependencies
+
+- chore(deps): Bump org.jetbrains.kotlinx:kotlinx-serialization-json from 1.10.0 to 1.11.0 by @dependabot[bot] in [PR #176](https://github.com/ichizero/connect-ktor/pull/176)
+- chore(deps): Bump gradle/actions from 6.0.1 to 6.1.0 by @dependabot[bot] in [PR #175](https://github.com/ichizero/connect-ktor/pull/175)
+- chore(deps): Bump ktor from 3.4.2 to 3.4.3 by @dependabot[bot] in [PR #180](https://github.com/ichizero/connect-ktor/pull/180)
+- chore(deps): Bump kotlin from 2.3.20 to 2.3.21 by @dependabot[bot] in [PR #181](https://github.com/ichizero/connect-ktor/pull/181)
+- chore(deps): Bump gradle-wrapper from 9.4.1 to 9.5.0 by @dependabot[bot] in [PR #184](https://github.com/ichizero/connect-ktor/pull/184)
+- chore(deps): Bump goreleaser/goreleaser-action from 7.0.0 to 7.2.1 by @dependabot[bot] in [PR #182](https://github.com/ichizero/connect-ktor/pull/182)
+- chore(deps): Bump dependabot/fetch-metadata from 3.0.0 to 3.1.0 by @dependabot[bot] in [PR #178](https://github.com/ichizero/connect-ktor/pull/178)
+- chore(deps): Bump build.buf:protovalidate from 1.1.2 to 1.2.2 by @dependabot[bot] in [PR #183](https://github.com/ichizero/connect-ktor/pull/183)
+- chore(deps): Bump gradle-wrapper from 9.5.0 to 9.5.1 by @dependabot[bot] in [PR #196](https://github.com/ichizero/connect-ktor/pull/196)
+- chore(deps): Bump org.slf4j:slf4j-simple from 2.0.17 to 2.0.18 by @dependabot[bot] in [PR #197](https://github.com/ichizero/connect-ktor/pull/197)
+- chore(deps): Bump spotless from 8.4.0 to 8.5.0 by @dependabot[bot] in [PR #198](https://github.com/ichizero/connect-ktor/pull/198)
+- chore(deps): Bump ktor from 3.4.3 to 3.5.0 by @dependabot[bot] in [PR #199](https://github.com/ichizero/connect-ktor/pull/199)
+- chore(deps): Bump github/codeql-action from 4.35.3 to 4.35.5 by @dependabot[bot] in [PR #202](https://github.com/ichizero/connect-ktor/pull/202)
+- chore(deps): Bump spotless from 8.5.0 to 8.5.1 by @dependabot[bot] in [PR #203](https://github.com/ichizero/connect-ktor/pull/203)
+- chore(deps): Bump goreleaser/goreleaser-action from 7.2.1 to 7.2.2 by @dependabot[bot] in [PR #206](https://github.com/ichizero/connect-ktor/pull/206)
+- chore(deps): Bump connect from 0.8.0 to 0.8.2 by @dependabot[bot] in [PR #209](https://github.com/ichizero/connect-ktor/pull/209)
+- chore(deps): Bump protobuf from 4.34.1 to 4.35.0 by @dependabot[bot] in [PR #208](https://github.com/ichizero/connect-ktor/pull/208)
+- chore(deps): Bump org.junit.jupiter:junit-jupiter-engine from 6.0.3 to 6.1.0 by @dependabot[bot] in [PR #207](https://github.com/ichizero/connect-ktor/pull/207)
+
+## connect-ktor@0.1.10
+
+### Dependencies
+
+- chore(deps): Bump org.junit.jupiter:junit-jupiter-engine from 6.0.2 to 6.0.3 by @dependabot[bot] in [PR #154](https://github.com/ichizero/connect-ktor/pull/154)
+- chore(deps): Bump goreleaser/goreleaser-action from 6.4.0 to 7.0.0 by @dependabot[bot] in [PR #155](https://github.com/ichizero/connect-ktor/pull/155)
+- chore(deps): Bump gradle/actions from 5.0.1 to 5.0.2 by @dependabot[bot] in [PR #156](https://github.com/ichizero/connect-ktor/pull/156)
+- chore(deps): Bump protobuf from 4.33.5 to 4.34.0 by @dependabot[bot] in [PR #158](https://github.com/ichizero/connect-ktor/pull/158)
+- chore(deps): Bump actions/setup-go from 6.2.0 to 6.3.0 by @dependabot[bot] in [PR #157](https://github.com/ichizero/connect-ktor/pull/157)
+- chore(deps): Bump ktor from 3.4.0 to 3.4.1 by @dependabot[bot] in [PR #160](https://github.com/ichizero/connect-ktor/pull/160)
+- chore(deps): Bump build.buf:protovalidate from 1.1.0 to 1.1.1 by @dependabot[bot] in [PR #162](https://github.com/ichizero/connect-ktor/pull/162)
+- chore(deps): Bump com.squareup.okio:okio from 3.16.4 to 3.17.0 by @dependabot[bot] in [PR #163](https://github.com/ichizero/connect-ktor/pull/163)
+- chore(deps): Bump gradle-wrapper from 9.3.1 to 9.4.0 by @dependabot[bot] in [PR #161](https://github.com/ichizero/connect-ktor/pull/161)
+- chore(deps): Bump spotless from 8.2.1 to 8.3.0 by @dependabot[bot] in [PR #159](https://github.com/ichizero/connect-ktor/pull/159)
+- chore(deps): Bump kotlin from 2.3.10 to 2.3.20 by @dependabot[bot] in [PR #164](https://github.com/ichizero/connect-ktor/pull/164)
+- chore(deps): Bump gradle-wrapper from 9.4.0 to 9.4.1 by @dependabot[bot] in [PR #167](https://github.com/ichizero/connect-ktor/pull/167)
+- chore(deps): Bump protobuf from 4.34.0 to 4.34.1 by @dependabot[bot] in [PR #168](https://github.com/ichizero/connect-ktor/pull/168)
+- chore(deps): Bump ktor from 3.4.1 to 3.4.2 by @dependabot[bot] in [PR #172](https://github.com/ichizero/connect-ktor/pull/172)
+- chore(deps): Bump build.buf:protovalidate from 1.1.1 to 1.1.2 by @dependabot[bot] in [PR #173](https://github.com/ichizero/connect-ktor/pull/173)
+- chore(deps): Bump actions/setup-go from 6.3.0 to 6.4.0 by @dependabot[bot] in [PR #174](https://github.com/ichizero/connect-ktor/pull/174)
+- chore(deps): Bump gradle/actions from 5.0.2 to 6.0.1 by @dependabot[bot] in [PR #170](https://github.com/ichizero/connect-ktor/pull/170)
+- chore(deps): Bump spotless from 8.3.0 to 8.4.0 by @dependabot[bot] in [PR #166](https://github.com/ichizero/connect-ktor/pull/166)
+- chore(deps): Bump dependabot/fetch-metadata from 2.5.0 to 3.0.0 by @dependabot[bot] in [PR #171](https://github.com/ichizero/connect-ktor/pull/171)
+- chore(deps): Bump connect from 0.7.4 to 0.8.0 by @dependabot[bot] in [PR #165](https://github.com/ichizero/connect-ktor/pull/165)
+
+## connect-ktor@0.1.9
+
+### Dependencies
+
+- chore(deps): Bump protobuf from 4.33.3 to 4.33.4 by @dependabot[bot] in [PR #141](https://github.com/ichizero/connect-ktor/pull/141)
+- chore(deps): Bump actions/checkout from 6.0.1 to 6.0.2 by @dependabot[bot] in [PR #146](https://github.com/ichizero/connect-ktor/pull/146)
+- chore(deps): Bump actions/setup-go from 6.1.0 to 6.2.0 by @dependabot[bot] in [PR #140](https://github.com/ichizero/connect-ktor/pull/140)
+- chore(deps): Bump actions/setup-java from 5.1.0 to 5.2.0 by @dependabot[bot] in [PR #144](https://github.com/ichizero/connect-ktor/pull/144)
+- chore(deps): Bump spotless from 8.1.0 to 8.2.0 by @dependabot[bot] in [PR #145](https://github.com/ichizero/connect-ktor/pull/145)
+- chore(deps): Bump com.vanniktech:gradle-maven-publish-plugin from 0.35.0 to 0.36.0 by @dependabot[bot] in [PR #142](https://github.com/ichizero/connect-ktor/pull/142)
+- chore(deps): Bump ktor from 3.3.3 to 3.4.0 by @dependabot[bot] in [PR #147](https://github.com/ichizero/connect-ktor/pull/147)
+- chore(deps): Bump org.jetbrains.kotlinx:kotlinx-serialization-json from 1.9.0 to 1.10.0 by @dependabot[bot] in [PR #143](https://github.com/ichizero/connect-ktor/pull/143)
+- chore(deps): Bump gradle-wrapper from 9.2.0 to 9.3.0 by @dependabot[bot] in [PR #148](https://github.com/ichizero/connect-ktor/pull/148)
+- chore(deps): Bump spotless from 8.2.0 to 8.2.1 by @dependabot[bot] in [PR #149](https://github.com/ichizero/connect-ktor/pull/149)
+- chore(deps): Bump gradle/actions from 5.0.0 to 5.0.1 by @dependabot[bot] in [PR #150](https://github.com/ichizero/connect-ktor/pull/150)
+- chore(deps): Bump protobuf from 4.33.4 to 4.33.5 by @dependabot[bot] in [PR #151](https://github.com/ichizero/connect-ktor/pull/151)
+- chore(deps): Bump gradle-wrapper from 9.3.0 to 9.3.1 by @dependabot[bot] in [PR #152](https://github.com/ichizero/connect-ktor/pull/152)
+- chore(deps): Bump kotlin from 2.3.0 to 2.3.10 by @dependabot[bot] in [PR #153](https://github.com/ichizero/connect-ktor/pull/153)
+
+## connect-ktor@0.1.8
+
+### Dependencies
+
+- chore(deps): Bump org.junit.jupiter:junit-jupiter-engine from 6.0.1 to 6.0.2 by @dependabot[bot] in [PR #138](https://github.com/ichizero/connect-ktor/pull/138)
+- chore(deps): Bump protobuf from 4.33.2 to 4.33.3 by @dependabot[bot] in [PR #139](https://github.com/ichizero/connect-ktor/pull/139)
+- chore(deps): Bump dependabot/fetch-metadata from 2.4.0 to 2.5.0 by @dependabot[bot] in [PR #137](https://github.com/ichizero/connect-ktor/pull/137)
+
+## connect-ktor@0.1.7
+
+### Dependencies
+
+- chore(deps): Bump actions/checkout from 5.0.0 to 5.0.1 by @dependabot[bot] in [PR #123](https://github.com/ichizero/connect-ktor/pull/123)
+- chore(deps): Bump com.squareup.okio:okio from 3.16.2 to 3.16.4 by @dependabot[bot] in [PR #124](https://github.com/ichizero/connect-ktor/pull/124)
+- chore(deps): Bump com.squareup.okhttp3:okhttp from 5.3.0 to 5.3.1 by @dependabot[bot] in [PR #125](https://github.com/ichizero/connect-ktor/pull/125)
+- chore(deps): Bump com.squareup.okhttp3:okhttp from 5.3.1 to 5.3.2 by @dependabot[bot] in [PR #127](https://github.com/ichizero/connect-ktor/pull/127)
+- chore(deps): Bump ktor from 3.3.2 to 3.3.3 by @dependabot[bot] in [PR #130](https://github.com/ichizero/connect-ktor/pull/130)
+- chore(deps): Bump spotless from 8.0.0 to 8.1.0 by @dependabot[bot] in [PR #126](https://github.com/ichizero/connect-ktor/pull/126)
+- chore(deps): Bump actions/checkout from 5.0.1 to 6.0.0 by @dependabot[bot] in [PR #128](https://github.com/ichizero/connect-ktor/pull/128)
+- chore(deps): Bump actions/setup-go from 6.0.0 to 6.1.0 by @dependabot[bot] in [PR #129](https://github.com/ichizero/connect-ktor/pull/129)
+- chore(deps): Bump actions/checkout from 6.0.0 to 6.0.1 by @dependabot[bot] in [PR #131](https://github.com/ichizero/connect-ktor/pull/131)
+- chore(deps): Bump protobuf from 4.33.1 to 4.33.2 by @dependabot[bot] in [PR #133](https://github.com/ichizero/connect-ktor/pull/133)
+- chore(deps): Bump actions/setup-java from 5.0.0 to 5.1.0 by @dependabot[bot] in [PR #132](https://github.com/ichizero/connect-ktor/pull/132)
+- chore(deps): Bump build.buf:protovalidate from 1.0.1 to 1.1.0 by @dependabot[bot] in [PR #134](https://github.com/ichizero/connect-ktor/pull/134)
+- chore(deps): Bump google.golang.org/protobuf from 1.36.10 to 1.36.11 in /protoc-gen-connect-ktor by @dependabot[bot] in [PR #135](https://github.com/ichizero/connect-ktor/pull/135)
+- chore(deps): Bump kotlin from 2.2.21 to 2.3.0 by @dependabot[bot] in [PR #136](https://github.com/ichizero/connect-ktor/pull/136)
+
+## connect-ktor@0.1.6
+
+### Dependencies
+
+- chore(deps): Bump kotlin from 2.2.20 to 2.2.21 by @dependabot[bot] in [PR #116](https://github.com/ichizero/connect-ktor/pull/116)
+- chore(deps): Bump build.buf:protovalidate from 1.0.0 to 1.0.1 by @dependabot[bot] in [PR #117](https://github.com/ichizero/connect-ktor/pull/117)
+- chore(deps): Bump org.junit.jupiter:junit-jupiter-engine from 6.0.0 to 6.0.1 by @dependabot[bot] in [PR #119](https://github.com/ichizero/connect-ktor/pull/119)
+- chore(deps): Bump ktor from 3.3.1 to 3.3.2 by @dependabot[bot] in [PR #120](https://github.com/ichizero/connect-ktor/pull/120)
+- chore(deps): Bump protobuf from 4.33.0 to 4.33.1 by @dependabot[bot] in [PR #122](https://github.com/ichizero/connect-ktor/pull/122)
+- chore(deps): Bump com.squareup.okhttp3:okhttp from 5.2.1 to 5.3.0 by @dependabot[bot] in [PR #118](https://github.com/ichizero/connect-ktor/pull/118)
+- chore(deps): Bump com.vanniktech:gradle-maven-publish-plugin from 0.34.0 to 0.35.0 by @dependabot[bot] in [PR #121](https://github.com/ichizero/connect-ktor/pull/121)
+
+## connect-ktor@0.1.5
+
+### Dependencies
+
+- chore(deps): Bump build.buf:protovalidate from 0.14.0 to 1.0.0 by @dependabot[bot] in [PR #106](https://github.com/ichizero/connect-ktor/pull/106)
+- chore(deps): Bump spotless from 7.2.1 to 8.0.0 by @dependabot[bot] in [PR #107](https://github.com/ichizero/connect-ktor/pull/107)
+- chore(deps): Bump org.junit.jupiter:junit-jupiter-engine from 5.13.4 to 6.0.0 by @dependabot[bot] in [PR #108](https://github.com/ichizero/connect-ktor/pull/108)
+- chore(deps): Bump google.golang.org/protobuf from 1.36.9 to 1.36.10 in /protoc-gen-connect-ktor by @dependabot[bot] in [PR #109](https://github.com/ichizero/connect-ktor/pull/109)
+- chore(deps): Bump ktor from 3.3.0 to 3.3.1 by @dependabot[bot] in [PR #111](https://github.com/ichizero/connect-ktor/pull/111)
+- chore(deps): Bump com.squareup.okio:okio from 3.16.0 to 3.16.1 by @dependabot[bot] in [PR #113](https://github.com/ichizero/connect-ktor/pull/113)
+- chore(deps): Bump com.squareup.okhttp3:okhttp from 5.1.0 to 5.2.1 by @dependabot[bot] in [PR #112](https://github.com/ichizero/connect-ktor/pull/112)
+- chore(deps): Bump com.squareup.okio:okio from 3.16.1 to 3.16.2 by @dependabot[bot] in [PR #114](https://github.com/ichizero/connect-ktor/pull/114)
+- chore(deps): Bump protobuf from 4.32.1 to 4.33.0 by @dependabot[bot] in [PR #115](https://github.com/ichizero/connect-ktor/pull/115)
+
+## connect-ktor@0.1.4
+
+### Dependencies
+
+- chore(deps): Bump google.golang.org/protobuf from 1.36.6 to 1.36.7 in /protoc-gen-connect-ktor by @dependabot[bot] in [PR #93](https://github.com/ichizero/connect-ktor/pull/93)
+- chore(deps): Bump kotlin from 2.2.0 to 2.2.10 by @dependabot[bot] in [PR #95](https://github.com/ichizero/connect-ktor/pull/95)
+- chore(deps): Bump google.golang.org/protobuf from 1.36.7 to 1.36.8 in /protoc-gen-connect-ktor by @dependabot[bot] in [PR #97](https://github.com/ichizero/connect-ktor/pull/97)
+- chore(deps): Bump actions/setup-java from 4 to 5 by @dependabot[bot] in [PR #98](https://github.com/ichizero/connect-ktor/pull/98)
+- chore(deps): Bump actions/checkout from 4 to 5 by @dependabot[bot] in [PR #94](https://github.com/ichizero/connect-ktor/pull/94)
+- chore(deps): Bump protobuf from 4.31.1 to 4.32.0 by @dependabot[bot] in [PR #96](https://github.com/ichizero/connect-ktor/pull/96)
+- chore(deps): Bump google.golang.org/protobuf from 1.36.8 to 1.36.9 in /protoc-gen-connect-ktor by @dependabot[bot] in [PR #101](https://github.com/ichizero/connect-ktor/pull/101)
+- chore(deps): Bump kotlin from 2.2.10 to 2.2.20 by @dependabot[bot] in [PR #102](https://github.com/ichizero/connect-ktor/pull/102)
+- chore(deps): Bump ktor from 3.2.3 to 3.3.0 by @dependabot[bot] in [PR #104](https://github.com/ichizero/connect-ktor/pull/104)
+- chore(deps): Bump build.buf:protovalidate from 0.13.0 to 0.14.0 by @dependabot[bot] in [PR #100](https://github.com/ichizero/connect-ktor/pull/100)
+- chore(deps): Bump actions/setup-go from 5 to 6 by @dependabot[bot] in [PR #99](https://github.com/ichizero/connect-ktor/pull/99)
+- chore(deps): Bump protobuf from 4.32.0 to 4.32.1 by @dependabot[bot] in [PR #103](https://github.com/ichizero/connect-ktor/pull/103)
+
+## connect-ktor@0.1.3
+
+### Dependencies
+
+- chore(deps): Bump org.junit.jupiter:junit-jupiter-engine from 5.13.1 to 5.13.2 by @dependabot[bot] in [PR #75](https://github.com/ichizero/connect-ktor/pull/75)
+- chore(deps): Bump kotlin from 2.1.21 to 2.2.0 by @dependabot[bot] in [PR #74](https://github.com/ichizero/connect-ktor/pull/74)
+- chore(deps): Bump com.vanniktech:gradle-maven-publish-plugin from 0.32.0 to 0.33.0 by @dependabot[bot] in [PR #73](https://github.com/ichizero/connect-ktor/pull/73)
+- chore(deps): Bump com.squareup.okio:okio from 3.13.0 to 3.14.0 by @dependabot[bot] in [PR #77](https://github.com/ichizero/connect-ktor/pull/77)
+- chore(deps): Bump connect from 0.7.3 to 0.7.4 by @dependabot[bot] in [PR #78](https://github.com/ichizero/connect-ktor/pull/78)
+- chore(deps): Bump org.jetbrains.kotlinx:kotlinx-serialization-json from 1.8.1 to 1.9.0 by @dependabot[bot] in [PR #76](https://github.com/ichizero/connect-ktor/pull/76)
+- chore(deps): Bump com.squareup.okio:okio from 3.14.0 to 3.15.0 by @dependabot[bot] in [PR #79](https://github.com/ichizero/connect-ktor/pull/79)
+- chore(deps): Bump ktor from 3.2.0 to 3.2.1 by @dependabot[bot] in [PR #80](https://github.com/ichizero/connect-ktor/pull/80)
+- chore(deps): Bump org.junit.jupiter:junit-jupiter-engine from 5.13.2 to 5.13.3 by @dependabot[bot] in [PR #82](https://github.com/ichizero/connect-ktor/pull/82)
+- chore(deps): Bump ktor from 3.2.1 to 3.2.2 by @dependabot[bot] in [PR #86](https://github.com/ichizero/connect-ktor/pull/86)
+- chore(deps): Bump spotless from 7.0.4 to 7.2.0 by @dependabot[bot] in [PR #88](https://github.com/ichizero/connect-ktor/pull/88)
+- chore(deps): Bump com.squareup.okhttp3:okhttp from 4.12.0 to 5.1.0 by @dependabot[bot] in [PR #83](https://github.com/ichizero/connect-ktor/pull/83)
+- chore(deps): Bump spotless from 7.2.0 to 7.2.1 by @dependabot[bot] in [PR #90](https://github.com/ichizero/connect-ktor/pull/90)
+- chore(deps): Bump ktor from 3.2.2 to 3.2.3 by @dependabot[bot] in [PR #91](https://github.com/ichizero/connect-ktor/pull/91)
+- chore(deps): Bump com.squareup.okio:okio from 3.15.0 to 3.16.0 by @dependabot[bot] in [PR #92](https://github.com/ichizero/connect-ktor/pull/92)
+- chore(deps): Bump build.buf:protovalidate from 0.12.0 to 0.13.0 by @dependabot[bot] in [PR #87](https://github.com/ichizero/connect-ktor/pull/87)
+- chore(deps): Bump org.junit.jupiter:junit-jupiter-engine from 5.13.3 to 5.13.4 by @dependabot[bot] in [PR #89](https://github.com/ichizero/connect-ktor/pull/89)
+- chore(deps): Bump com.vanniktech:gradle-maven-publish-plugin from 0.33.0 to 0.34.0 by @dependabot[bot] in [PR #85](https://github.com/ichizero/connect-ktor/pull/85)
+
+## connect-ktor@0.1.2
+
+### Dependencies
+
+- chore(deps): Bump org.gradle.toolchains.foojay-resolver-convention from 0.10.0 to 1.0.0 by @dependabot in [PR #60](https://github.com/ichizero/connect-ktor/pull/60)
+- chore(deps): Bump spotless from 7.0.3 to 7.0.4 by @dependabot in [PR #61](https://github.com/ichizero/connect-ktor/pull/61)
+- chore(deps): Bump com.squareup.okio:okio from 3.11.0 to 3.12.0 by @dependabot in [PR #62](https://github.com/ichizero/connect-ktor/pull/62)
+- chore(deps): Bump protobuf from 4.31.0 to 4.31.1 by @dependabot in [PR #63](https://github.com/ichizero/connect-ktor/pull/63)
+- chore(deps): Bump org.junit.jupiter:junit-jupiter-engine from 5.12.2 to 5.13.0 by @dependabot in [PR #64](https://github.com/ichizero/connect-ktor/pull/64)
+- chore(deps): Bump org.junit.jupiter:junit-jupiter-engine from 5.13.0 to 5.13.1 by @dependabot in [PR #67](https://github.com/ichizero/connect-ktor/pull/67)
+- chore(deps): Bump build.buf:protovalidate from 0.8.0 to 0.10.0 by @dependabot in [PR #68](https://github.com/ichizero/connect-ktor/pull/68)
+- chore(deps): Bump ktor from 3.1.3 to 3.2.0 by @dependabot in [PR #69](https://github.com/ichizero/connect-ktor/pull/69)
+- chore(deps): Bump build.buf:protovalidate from 0.10.0 to 0.11.0 by @dependabot in [PR #70](https://github.com/ichizero/connect-ktor/pull/70)
+- chore(deps): Bump com.squareup.okio:okio from 3.12.0 to 3.13.0 by @dependabot in [PR #71](https://github.com/ichizero/connect-ktor/pull/71)
+- chore(deps): Bump build.buf:protovalidate from 0.11.0 to 0.12.0 by @dependabot in [PR #72](https://github.com/ichizero/connect-ktor/pull/72)
+
+## connect-ktor@0.1.1
+
+### Dependencies
+
+- chore(deps): Bump connect from 0.7.2 to 0.7.3 by @dependabot in [PR #54](https://github.com/ichizero/connect-ktor/pull/54)
+- chore(deps): Bump build.buf:protovalidate from 0.7.0 to 0.7.2 by @dependabot in [PR #55](https://github.com/ichizero/connect-ktor/pull/55)
+- chore(deps): Bump kotlin from 2.1.20 to 2.1.21 by @dependabot in [PR #56](https://github.com/ichizero/connect-ktor/pull/56)
+- chore(deps): Bump protobuf from 4.30.2 to 4.31.0 by @dependabot in [PR #58](https://github.com/ichizero/connect-ktor/pull/58)
+- chore(deps): Bump com.vanniktech:gradle-maven-publish-plugin from 0.31.0 to 0.32.0 by @dependabot in [PR #59](https://github.com/ichizero/connect-ktor/pull/59)
+- chore(deps): Bump build.buf:protovalidate from 0.7.2 to 0.8.0 by @dependabot in [PR #57](https://github.com/ichizero/connect-ktor/pull/57)
+
+## connect-ktor@0.1.0
+
+### Dependencies
+
+- chore(deps): Bump com.vanniktech:gradle-maven-publish-plugin from 0.30.0 to 0.31.0 by @dependabot in [PR #39](https://github.com/ichizero/connect-ktor/pull/39)
+- chore(deps): Bump org.junit.jupiter:junit-jupiter-engine from 5.11.4 to 5.12.0 by @dependabot in [PR #36](https://github.com/ichizero/connect-ktor/pull/36)
+- chore(deps): Bump protobuf from 4.29.3 to 4.30.0 by @dependabot in [PR #38](https://github.com/ichizero/connect-ktor/pull/38)
+- chore(deps): Bump ktor from 3.1.0 to 3.1.1 by @dependabot in [PR #37](https://github.com/ichizero/connect-ktor/pull/37)
+- chore(deps): Bump protobuf from 4.30.0 to 4.30.1 by @dependabot in [PR #40](https://github.com/ichizero/connect-ktor/pull/40)
+- chore(deps): Bump org.junit.jupiter:junit-jupiter-engine from 5.12.0 to 5.12.1 by @dependabot in [PR #41](https://github.com/ichizero/connect-ktor/pull/41)
+- chore(deps): Bump kotlin from 2.1.10 to 2.1.20 by @dependabot in [PR #42](https://github.com/ichizero/connect-ktor/pull/42)
+- chore(deps): Bump google.golang.org/protobuf from 1.36.5 to 1.36.6 in /protoc-gen-connect-ktor by @dependabot in [PR #44](https://github.com/ichizero/connect-ktor/pull/44)
+- chore(deps): Bump protobuf from 4.30.1 to 4.30.2 by @dependabot in [PR #45](https://github.com/ichizero/connect-ktor/pull/45)
+- chore(deps): Bump ktor from 3.1.1 to 3.1.2 by @dependabot in [PR #46](https://github.com/ichizero/connect-ktor/pull/46)
+- chore(deps): Bump org.jetbrains.kotlinx:kotlinx-serialization-json from 1.8.0 to 1.8.1 by @dependabot in [PR #47](https://github.com/ichizero/connect-ktor/pull/47)
+- chore(deps): Bump spotless from 7.0.2 to 7.0.3 by @dependabot in [PR #48](https://github.com/ichizero/connect-ktor/pull/48)
+- chore(deps): Bump org.junit.jupiter:junit-jupiter-engine from 5.12.1 to 5.12.2 by @dependabot in [PR #51](https://github.com/ichizero/connect-ktor/pull/51)
+- chore(deps): Bump com.squareup.okio:okio from 3.10.2 to 3.11.0 by @dependabot in [PR #49](https://github.com/ichizero/connect-ktor/pull/49)
+- chore(deps): Bump org.gradle.toolchains.foojay-resolver-convention from 0.9.0 to 0.10.0 by @dependabot in [PR #50](https://github.com/ichizero/connect-ktor/pull/50)
+- chore(deps): Bump ktor from 3.1.2 to 3.1.3 by @dependabot in [PR #53](https://github.com/ichizero/connect-ktor/pull/53)
+- chore(deps): Bump build.buf:protovalidate from 0.5.0 to 0.7.0 by @dependabot in [PR #52](https://github.com/ichizero/connect-ktor/pull/52)
+
+## connect-ktor@0.0.7
+
+### Correct input type in route handler definition
+
+[PR #34](https://github.com/ichizero/connect-ktor/pull/34)
+
+## connect-ktor@0.0.6
+
+### Add proto3 optional feature support
+
+[PR #33](https://github.com/ichizero/connect-ktor/pull/33)
+
+### Dependencies
+
+- chore(deps): Bump ktor from 3.0.3 to 3.1.0 by @dependabot in [PR #32](https://github.com/ichizero/connect-ktor/pull/32)
+
+## connect-ktor@0.0.5
+
+### Rewrite plugin in Go
+
+[PR #31](https://github.com/ichizero/connect-ktor/pull/31)
+
+## connect-ktor@0.0.4
+
+### Dependencies
+
+- chore(deps): Bump org.junit.jupiter:junit-jupiter-engine from 5.11.3 to 5.11.4 by @dependabot in [PR #17](https://github.com/ichizero/connect-ktor/pull/17)
+- chore(deps): Bump ktor from 3.0.2 to 3.0.3 by @dependabot in [PR #18](https://github.com/ichizero/connect-ktor/pull/18)
+- chore(deps): Bump protobuf from 4.29.1 to 4.29.2 by @dependabot in [PR #19](https://github.com/ichizero/connect-ktor/pull/19)
+- chore(deps): Bump protobuf from 4.29.2 to 4.29.3 by @dependabot in [PR #25](https://github.com/ichizero/connect-ktor/pull/25)
+- chore(deps): Bump connect from 0.7.1 to 0.7.2 by @dependabot in [PR #27](https://github.com/ichizero/connect-ktor/pull/27)
+- chore(deps): Bump org.jetbrains.kotlinx:kotlinx-serialization-json from 1.7.3 to 1.8.0 by @dependabot in [PR #22](https://github.com/ichizero/connect-ktor/pull/22)
+- chore(deps): Bump com.squareup.okio:okio from 3.9.1 to 3.10.2 by @dependabot in [PR #26](https://github.com/ichizero/connect-ktor/pull/26)
+- chore(deps): Bump spotless from 6.25.0 to 7.0.2 by @dependabot in [PR #28](https://github.com/ichizero/connect-ktor/pull/28)
+- chore(deps): Bump kotlin from 2.1.0 to 2.1.10 by @dependabot in [PR #29](https://github.com/ichizero/connect-ktor/pull/29)
+- chore(deps): Bump com.gradleup.shadow from 8.3.5 to 8.3.6 by @dependabot in [PR #30](https://github.com/ichizero/connect-ktor/pull/30)
+- chore(deps): Bump build.buf:protovalidate from 0.4.2 to 0.5.0 by @dependabot in [PR #16](https://github.com/ichizero/connect-ktor/pull/16)
+
+## connect-ktor@0.0.3
+
+### Add validation plugin with protovalidate
+
+[PR #15](https://github.com/ichizero/connect-ktor/pull/15)
+
+### Dependencies
+
+- chore(deps): Bump connect from 0.7.0 to 0.7.1 by @dependabot in [PR #9](https://github.com/ichizero/connect-ktor/pull/9)
+- chore(deps): Bump kotlin from 2.0.21 to 2.1.0 by @dependabot in [PR #11](https://github.com/ichizero/connect-ktor/pull/11)
+- chore(deps): Bump protobuf from 4.28.3 to 4.29.0 by @dependabot in [PR #10](https://github.com/ichizero/connect-ktor/pull/10)
+- chore(deps): Bump org.gradle.toolchains.foojay-resolver-convention from 0.8.0 to 0.9.0 by @dependabot in [PR #12](https://github.com/ichizero/connect-ktor/pull/12)
+- chore(deps): Bump ktor from 3.0.1 to 3.0.2 by @dependabot in [PR #13](https://github.com/ichizero/connect-ktor/pull/13)
+- chore(deps): Bump protobuf from 4.29.0 to 4.29.1 by @dependabot in [PR #14](https://github.com/ichizero/connect-ktor/pull/14)
+
+## connect-ktor@0.0.2
+
+### Add support for proto serialization/deserialization
+
+[PR #7](https://github.com/ichizero/connect-ktor/pull/7)
+
+### Provide util functions from lib
+
+[PR #8](https://github.com/ichizero/connect-ktor/pull/8)
+
+### Release executable jar
+
+[PR #6](https://github.com/ichizero/connect-ktor/pull/6)
+
+### Dependencies
+
+- chore(deps): Bump com.squareup:kotlinpoet from 1.18.1 to 2.0.0 by @dependabot in [PR #2](https://github.com/ichizero/connect-ktor/pull/2)
+- chore(deps): Bump org.junit.jupiter:junit-jupiter-engine from 5.11.2 to 5.11.3 by @dependabot in [PR #4](https://github.com/ichizero/connect-ktor/pull/4)
+- chore(deps): Bump ktor from 3.0.0 to 3.0.1 by @dependabot in [PR #5](https://github.com/ichizero/connect-ktor/pull/5)
+- chore(deps): Bump protobuf from 4.28.2 to 4.28.3 by @dependabot in [PR #3](https://github.com/ichizero/connect-ktor/pull/3)
+
+## connect-ktor@0.0.1
+
+### Implement protoc-gen-connect-ktor
+
+[PR #1](https://github.com/ichizero/connect-ktor/pull/1)


### PR DESCRIPTION
## Summary
- Backfill root `CHANGELOG.md` from historical docs-site changelog MDX (`connect-ktor@0.2.0` through `0.0.1`) using the Version Packages heading style (`## connect-ktor@x.y.z`, `###` feature headings, `[PR #N](url)` links).
- Add a Tegami Dependabot entry at `.tegami/2026-08-02-dependencies.md` (`packages.connect-ktor: patch`) generated with `./scripts/tegami-deps-summary.sh --since v0.2.0`.

## Relationship to #276
This PR is based on `main` and is intended to merge **before** Version Packages (#276).

- Merge this backfill PR to `main` first.
- Then rebase / update #276 onto `main` so Version Packages can prepend `connect-ktor@0.3.0` on top of the historical changelog and continue the release flow.
- Do not merge #276 first; that would leave this PR conflicting on `CHANGELOG.md` and Version Packages files.

## Test plan
- [ ] `CHANGELOG.md` starts at `## connect-ktor@0.2.0` and includes versions down to `0.0.1` in newest-first order
- [ ] Headings use `## connect-ktor@x.y.z` / `###` feature sections; PR refs use `[PR #N](url)`
- [ ] `.tegami/2026-08-02-dependencies.md` has `packages.connect-ktor: patch` and a `## Dependencies` body matching the script output
- [ ] CI is green or skipped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a comprehensive changelog covering releases 0.0.1 through 0.2.0.
  - Documented client-streaming RPC support, protocol compliance, plugin and serialization improvements, routing and proto3 updates, executable-jar releases, and dependency upgrades.
  - Added a dependency update record covering build, testing, formatting, security, and development-tooling updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->