### PR TITLE
feat: support Connect server-streaming RPCs (STREAM_TYPE_SERVER_STREAM)

### DIFF
--- a/.tegami/2026-08-02-server-streaming.md
+++ b/.tegami/2026-08-02-server-streaming.md
@@ -1,0 +1,19 @@
+---
+packages:
+    connect-ktor: minor
+---
+
+## Support Connect server-streaming RPCs
+
+Server-streaming RPCs (`rpc X(Req) returns (stream Res)`) are now served end to end.
+The code generator emits handlers that return a cold `Flow<Res>`, and
+`handleServerStream` writes each emitted message as an envelope frame followed by an
+end-of-stream frame. Response headers are flushed before the first message, a
+`ConnectException` thrown by the flow becomes the end-of-stream error, and trailers can
+be set through the new `call.connectResponseTrailers()`. When a client disconnects, the
+handler's flow collector is cancelled instead of the failure being swallowed.
+
+Services with server-streaming methods in their `.proto` will see a new member on the
+generated handler interface — those methods used to be skipped by the generator.
+
+[PR #278](https://github.com/ichizero/connect-ktor/pull/278)

--- a/.tegami/2026-08-02-server-streaming.md
+++ b/.tegami/2026-08-02-server-streaming.md
@@ -1,6 +1,6 @@
 ---
 packages:
-    connect-ktor: minor
+  connect-ktor: minor
 ---
 
 ## Support Connect server-streaming RPCs

--- a/README.md
+++ b/README.md
@@ -19,10 +19,11 @@ organization). For Connect itself and Connect-Kotlin clients, prefer the officia
 
 ## Features
 
-- **connect-ktor** — Protobuf JSON/binary codecs via Connect-Kotlin, client-streaming
-  RPCs with envelope framing, optional [protovalidate](https://github.com/bufbuild/protovalidate)
-- **protoc-gen-connect-ktor** — generates Ktor route handler interfaces (unary +
-  client-streaming `Flow<Req>`)
+- **connect-ktor** — Protobuf JSON/binary codecs via Connect-Kotlin, client- and
+  server-streaming RPCs with envelope framing, optional
+  [protovalidate](https://github.com/bufbuild/protovalidate)
+- **protoc-gen-connect-ktor** — generates Ktor route handler interfaces (unary,
+  client-streaming `Flow<Req>`, server-streaming `Flow<Res>`)
 
 Plugins (Connect GET, body limits, compression guards, and more), engine notes,
 and longer guides live in the [documentation site](https://ichizero.github.io/connect-ktor/).
@@ -44,15 +45,15 @@ Summary (details and footnotes:
 | Codec                 | Proto / JSON                 |  ✅  |  ✅   |
 | Compression           | identity / gzip              |  ✅  |  ✅   |
 |                       | br / zstd / deflate / snappy |  ❌  |  ❌   |
-| Streams               | unary / client-stream        |  ✅  |  ✅   |
-|                       | server / bidi                |  ❌  |  ❌   |
+| Streams               | unary / client / server      |  ✅  |  ✅   |
+|                       | bidi                         |  ❌  |  ❌   |
 | TLS / mTLS            |                              |  ❌  |  ✅   |
 | Trailers              |                              |  ✅  |  ✅   |
 | Connect GET           |                              | ✅\* |  ✅   |
 | Message receive limit | unary                        |  ✅  |  ✅   |
 
 \* CIO Connect GET fails cases that rely on duplicate request headers (upstream
-CIO limitation). Both engines currently fail gzip client-stream cases (per-message
+CIO limitation). Both engines currently fail gzip streaming cases (per-message
 streaming compression unimplemented).
 
 ```bash

--- a/apps/docs-site/content/code-generator.mdx
+++ b/apps/docs-site/content/code-generator.mdx
@@ -6,7 +6,7 @@ description: protoc-gen-connect-ktor generates Ktor handler interfaces from .pro
 # Code generator
 
 `protoc-gen-connect-ktor` turns service RPCs into Kotlin interfaces and `Route` helpers.
-You implement the interface; the generator owns path wiring and the choice between `handle` and `handleClientStream`.
+You implement the interface; the generator owns path wiring and the choice between `handle`, `handleClientStream`, and `handleServerStream`.
 
 ## What it emits
 
@@ -22,27 +22,55 @@ public interface ElizaServiceHandlerInterface {
         call: ApplicationCall,
     ): ResponseMessage<UploadResponse>
 
+    public suspend fun introduce(
+        request: IntroduceRequest,
+        call: ApplicationCall,
+    ): Flow<IntroduceResponse>
+
     public object Procedures {
         @Resource("/connectrpc.eliza.v1.ElizaService/Say")
         public class Say
 
         @Resource("/connectrpc.eliza.v1.ElizaService/Upload")
         public class Upload
+
+        @Resource("/connectrpc.eliza.v1.ElizaService/Introduce")
+        public class Introduce
     }
 }
 
 public fun Route.elizaService(handler: ElizaServiceHandlerInterface) {
     post<ElizaServiceHandlerInterface.Procedures.Say, SayRequest>(handle(handler::say))
     post<ElizaServiceHandlerInterface.Procedures.Upload>(handleClientStream(handler::upload))
+    post<ElizaServiceHandlerInterface.Procedures.Introduce>(handleServerStream(handler::introduce))
 }
 ```
 
 Unary RPCs receive one message.
 Client-streaming RPCs (`rpc X(stream Req) returns (Res)`) receive a cold `Flow<Req>`.
+Server-streaming RPCs (`rpc X(Req) returns (stream Res)`) receive one message and return a cold `Flow<Res>`.
+
+A server-streaming handler reports its outcome through the flow: normal completion ends the stream,
+and a thrown `ConnectException` becomes the error in the end-of-stream frame. Response headers go on
+`call.response.headers` before the flow is collected; trailers go on `call.connectResponseTrailers()`,
+which is read when the end-of-stream frame is written.
+
+```kotlin
+override suspend fun introduce(
+    request: IntroduceRequest,
+    call: ApplicationCall,
+): Flow<IntroduceResponse> {
+    call.connectResponseTrailers().append("x-sentence-count", "2")
+    return flow {
+        emit(introduceResponse { sentence = "Hi ${request.name}!" })
+        emit(introduceResponse { sentence = "I'm Eliza." })
+    }
+}
+```
 
 ## What it skips
 
-Server-streaming and bidirectional RPCs are not generated today.
+Bidirectional RPCs are not generated today.
 The plugin skips those methods rather than emitting stubs that cannot run.
 Track that gap under [Known limitations](/known-limitations).
 

--- a/apps/docs-site/content/conformance.mdx
+++ b/apps/docs-site/content/conformance.mdx
@@ -29,7 +29,7 @@ project — this page only records how far connect-ktor implements them.
 |                       | `BR` / `ZSTD` / `DEFLATE` / `SNAPPY`          |  ❌  |  ❌   |
 | Stream type           | Unary                                         |  ✅  |  ✅   |
 |                       | Client stream                                 |  ✅  |  ✅   |
-|                       | Server stream                                 |  ❌  |  ❌   |
+|                       | Server stream                                 |  ✅  |  ✅   |
 |                       | Half-/full-duplex bidi                        |  ❌  |  ❌   |
 | TLS                   | TLS                                           |  ❌  |  ✅   |
 |                       | mTLS                                          |  ❌  |  ✅   |
@@ -41,8 +41,11 @@ project — this page only records how far connect-ktor implements them.
 CIO collapses those headers upstream — the same limitation as the
 `Duplicate Metadata` / `Basic` pins in `conformance/known-failing-cio.txt`.
 
-Both engines currently fail gzip **client-stream** cases because per-message
-streaming compression is unimplemented (pinned as known-failing / known-flaky).
+Both engines currently fail gzip **client-stream** and **server-stream** cases
+because per-message streaming compression is unimplemented (pinned as
+known-failing / known-flaky). The `Server Message Size` streaming cases are
+pinned too: `connectBodyLimit` caps the whole request body instead of applying a
+per-message receive limit.
 
 ## Engines
 

--- a/apps/docs-site/content/conformance.mdx
+++ b/apps/docs-site/content/conformance.mdx
@@ -44,8 +44,9 @@ CIO collapses those headers upstream — the same limitation as the
 Both engines currently fail gzip **client-stream** and **server-stream** cases
 because per-message streaming compression is unimplemented (pinned as
 known-failing / known-flaky). The `Server Message Size` streaming cases are
-pinned too: `connectBodyLimit` caps the whole request body instead of applying a
-per-message receive limit.
+pinned too: the harness applies the requested limit through `connectBodyLimit`, which
+caps the whole body including envelope prefixes. Generated streaming routes retain
+their separate, default 4 MiB per-message limit.
 
 ## Engines
 

--- a/apps/docs-site/content/getting-started.mdx
+++ b/apps/docs-site/content/getting-started.mdx
@@ -59,7 +59,7 @@ plugins:
 buf generate
 ```
 
-For a service like Eliza's `Say` RPC, the plugin emits a handler interface and a `Route` extension that wires `handle` / `handleClientStream`.
+For a service like Eliza's `Say` RPC, the plugin emits a handler interface and a `Route` extension that wires `handle` / `handleClientStream` / `handleServerStream`.
 
 ## Implement the handler
 
@@ -78,6 +78,7 @@ object ElizaServiceHandler : ElizaServiceHandlerInterface {
 
 Unary methods take a single request.
 Client-streaming methods take a cold `Flow<Req>` and still return one `ResponseMessage`.
+Server-streaming methods take a single request and return a cold `Flow<Res>`.
 
 ## Register beside REST
 

--- a/apps/docs-site/content/introduction.mdx
+++ b/apps/docs-site/content/introduction.mdx
@@ -33,12 +33,12 @@ That is why it fits an existing Ktor app: you add handlers, you do not replace t
 
 ## What you get today
 
-- Unary and client-streaming Connect handlers on CIO and Netty
+- Unary, client-streaming, and server-streaming Connect handlers on CIO and Netty
 - `connectJson()` / `connectProto()` ContentNegotiation codecs
 - Generated Ktor route interfaces via `protoc-gen-connect-ktor`
 - Optional protovalidate request checks, body size limits, and gzip guards
 
-Server-streaming, bidi, and gRPC/gRPC-Web are still out of scope.
+Bidi streaming and gRPC/gRPC-Web are still out of scope.
 See [Known limitations](/known-limitations) for the honest matrix, and [Conformance](/conformance) for what the suite actually exercises.
 
 ## Relationship to Connect-Kotlin
@@ -62,7 +62,7 @@ A React app on Connect-ES and a Ktor service on Connect-Ktor can share one Buf m
 
 - Teams with a Ktor REST API who want Protobuf RPCs for new or hot paths
 - Stacks that already pair **React (Connect-ES)** with **Kotlin/Ktor**
-- Services that need Connect conformance for unary and client-streaming today, and can wait on server/bidi streaming
+- Services that need Connect conformance for unary, client-streaming, and server-streaming today, and can wait on bidi streaming
 
 It is a poor fit if you need gRPC wire compatibility or full-duplex streams on day one.
 Those limits stay under [Known limitations](/known-limitations), not hidden behind a feature checklist.

--- a/apps/docs-site/content/known-limitations.mdx
+++ b/apps/docs-site/content/known-limitations.mdx
@@ -11,7 +11,7 @@ The limits below are deliberate scope choices, not silent bugs.
 ## Protocol surface
 
 - **gRPC / gRPC-Web** — Connect only. Official Connect implementations can speak gRPC as well; see the [Connect protocol](https://connectrpc.com/docs/protocol) and language guides on [connectrpc.com](https://connectrpc.com/) when that interop is required. Here, gRPC would need length-prefixed framing and trailer-only error responses.
-- **Server-streaming and bidi** — Client streaming works via `handleClientStream` and the generator. Server and bidirectional streams need more generator branches and a streaming response writer. Bidi also needs HTTP/2. The full stream taxonomy is documented in the official protocol / language docs.
+- **Bidirectional streaming** — Client streaming (`handleClientStream`) and server streaming (`handleServerStream`) are generated and conformance-tested. Bidi streams still need a full-duplex handler shape and HTTP/2. The full stream taxonomy is documented in the official protocol / language docs.
 
 ## Engines
 
@@ -21,8 +21,8 @@ The limits below are deliberate scope choices, not silent bugs.
 ## Compression and limits
 
 - **Extra content encodings** — `br`, `zstd`, and `snappy` need custom Ktor `ContentEncoder`s plus matching entries in `UnaryCompressionGuard.supportedEncodings`.
-- **Client-stream gzip** — Per-message streaming compression is unimplemented; related conformance cases stay known-failing.
-- **Per-message receive limits on client streams** — `connectBodyLimit` caps the whole request body. Unary equals one message; client-stream needs a different mechanism.
+- **Streaming gzip** — Per-message streaming compression is unimplemented; the related client-stream and server-stream conformance cases stay known-failing.
+- **Per-message receive limits on streams** — `connectBodyLimit` caps the whole request body. Unary equals one message; client-stream and server-stream need a different mechanism.
 
 ## Product status
 

--- a/apps/docs-site/content/known-limitations.mdx
+++ b/apps/docs-site/content/known-limitations.mdx
@@ -22,7 +22,7 @@ The limits below are deliberate scope choices, not silent bugs.
 
 - **Extra content encodings** — `br`, `zstd`, and `snappy` need custom Ktor `ContentEncoder`s plus matching entries in `UnaryCompressionGuard.supportedEncodings`.
 - **Streaming gzip** — Per-message streaming compression is unimplemented; the related client-stream and server-stream conformance cases stay known-failing.
-- **Per-message receive limits on streams** — `connectBodyLimit` caps the whole request body. Unary equals one message; client-stream and server-stream need a different mechanism.
+- **Streaming receive-limit configuration** — `handleClientStream` and `handleServerStream` enforce `maxMessageSize` on each request envelope payload (4 MiB by default). Generated routes use that default; a custom limit requires manual route binding. `connectBodyLimit` separately caps the entire request body, including envelope prefixes, and does not configure the per-message limit.
 
 ## Product status
 

--- a/conformance/config-cio.yaml
+++ b/conformance/config-cio.yaml
@@ -12,6 +12,7 @@ features:
   stream_types:
     - STREAM_TYPE_UNARY
     - STREAM_TYPE_CLIENT_STREAM
+    - STREAM_TYPE_SERVER_STREAM
   supports_h2c: false
   # CIO does not implement HTTPS upstream
   # (UnsupportedOperationException: CIO Engine does not currently support HTTPS).

--- a/conformance/config-netty.yaml
+++ b/conformance/config-netty.yaml
@@ -13,6 +13,7 @@ features:
   stream_types:
     - STREAM_TYPE_UNARY
     - STREAM_TYPE_CLIENT_STREAM
+    - STREAM_TYPE_SERVER_STREAM
   supports_h2c: true
   supports_tls: true
   supports_tls_client_certs: true

--- a/conformance/known-failing-cio.txt
+++ b/conformance/known-failing-cio.txt
@@ -6,7 +6,16 @@
 # without switching engines. This is a CIO upstream limitation, not a
 # connect-ktor regression, and is treated as out-of-scope for the Connect GET
 # work (PR #194 / issue #189): all listed cases pass on Netty.
-Duplicate Metadata/**
+#
+# `Duplicate Metadata` is listed per stream type rather than as a single
+# `Duplicate Metadata/**` glob: its `server-stream/no-response` case sends no
+# duplicate request headers (it has no requestHeaders at all), so it passes on
+# CIO and a blanket glob would be reported as "expected to fail but did not".
+Duplicate Metadata/**/unary/*
+Duplicate Metadata/**/client-stream/*
+Duplicate Metadata/**/server-stream/success
+Duplicate Metadata/**/server-stream/error-with-responses
+Duplicate Metadata/**/server-stream/error-with-no-responses
 # Reference client sends duplicate "X-Conformance-Test" headers in these cases;
 # CIO collapses them so the echoed request_info disagrees with the expectation.
 # Listed with the exact case names so an unrelated regression in `Basic` or
@@ -15,8 +24,15 @@ Basic/HTTPVersion:1/Protocol:PROTOCOL_CONNECT/Codec:CODEC_PROTO/Compression:COMP
 Basic/HTTPVersion:1/Protocol:PROTOCOL_CONNECT/Codec:CODEC_JSON/Compression:COMPRESSION_IDENTITY/TLS:false/unary/success
 Basic/HTTPVersion:1/Protocol:PROTOCOL_CONNECT/Codec:CODEC_PROTO/Compression:COMPRESSION_IDENTITY/TLS:false/client-stream/success
 Basic/HTTPVersion:1/Protocol:PROTOCOL_CONNECT/Codec:CODEC_JSON/Compression:COMPRESSION_IDENTITY/TLS:false/client-stream/success
+Basic/HTTPVersion:1/Protocol:PROTOCOL_CONNECT/Codec:CODEC_PROTO/Compression:COMPRESSION_IDENTITY/TLS:false/server-stream/success
+Basic/HTTPVersion:1/Protocol:PROTOCOL_CONNECT/Codec:CODEC_JSON/Compression:COMPRESSION_IDENTITY/TLS:false/server-stream/success
 Basic/HTTPVersion:1/Protocol:PROTOCOL_CONNECT/Codec:CODEC_PROTO/Compression:COMPRESSION_GZIP/TLS:false/unary/success
 Basic/HTTPVersion:1/Protocol:PROTOCOL_CONNECT/Codec:CODEC_JSON/Compression:COMPRESSION_GZIP/TLS:false/unary/success
+# Same duplicate-header collapsing, on the two server-stream error cases that
+# echo request_info back (`server-stream/no-responses` sends no message, so its
+# request_info is never compared and it still passes on CIO).
+Errors/**/Compression:COMPRESSION_IDENTITY/**/server-stream/error-with-responses
+Errors/**/Compression:COMPRESSION_IDENTITY/**/server-stream/error-with-no-responses
 Server Empty Requests/HTTPVersion:1/Protocol:PROTOCOL_CONNECT/TLS:false/unary/empty-request
 Server Empty Requests/HTTPVersion:1/Protocol:PROTOCOL_CONNECT/TLS:false/client-stream/empty-request
 # The two GET cases below also fail solely due to CIO's duplicate-header
@@ -27,22 +43,31 @@ Connect with GET/HTTPVersion:1/Codec:CODEC_PROTO/TLS:false/success
 Connect with GET/HTTPVersion:1/Codec:CODEC_JSON/TLS:false/success
 
 # Per-message (envelope) compression for streaming RPCs is not implemented yet
-# (see issue #190): handleClientStream rejects a non-identity
-# `Connect-Content-Encoding` and any compressed envelope frame with
-# CODE_UNIMPLEMENTED. The conformance config advertises COMPRESSION_GZIP for the
-# whole server, so the runner also exercises gzip against client-stream, where
-# every case fails the same way. Unary gzip is fully supported. The Timeouts
-# suite races the rejection against the deadline and is tracked in
-# known-flaky-cio.txt instead.
+# (see issue #190): the streaming handlers reject a non-identity
+# `Connect-Content-Encoding` with CODE_UNIMPLEMENTED. The conformance config
+# advertises COMPRESSION_GZIP for the whole server, so the runner also exercises
+# gzip against the streaming RPCs, where every case fails the same way. Unary
+# gzip is fully supported. The Timeouts suite races the rejection against the
+# deadline and is tracked in known-flaky-cio.txt instead.
 Basic/**/Compression:COMPRESSION_GZIP/**/client-stream/**
+Basic/**/Compression:COMPRESSION_GZIP/**/server-stream/**
 Connect to HTTP Code Mapping/**/Compression:COMPRESSION_GZIP/**/client-stream/**
+Connect to HTTP Code Mapping/**/Compression:COMPRESSION_GZIP/**/server-stream/**
 Deadline Propagation/**/Compression:COMPRESSION_GZIP/**/client-stream/**
+Deadline Propagation/**/Compression:COMPRESSION_GZIP/**/server-stream/**
 Errors/**/Compression:COMPRESSION_GZIP/**/client-stream/**
+Errors/**/Compression:COMPRESSION_GZIP/**/server-stream/**
+# The rest of `Duplicate Metadata` is already pinned above by the duplicate
+# request header limitation; only this case passes on identity and needs the
+# gzip variant pinned separately.
+Duplicate Metadata/**/Compression:COMPRESSION_GZIP/**/server-stream/no-response
 
 # `connectBodyLimit` enforces a whole-body byte cap, which equals a single
-# message for unary RPCs. Client-streaming needs a per-message receive limit
-# (and a streaming end-of-stream error frame): the whole-body cap both
-# over-rejects when individual messages are within the limit but their sum is
-# not, and surfaces the overflow as CODE_UNKNOWN instead of RESOURCE_EXHAUSTED.
+# message for unary RPCs. Streaming RPCs need a per-message receive limit (and a
+# streaming end-of-stream error frame): the whole-body cap also counts the 5 byte
+# envelope prefix, over-rejects when individual messages are within the limit but
+# their sum is not, and surfaces the overflow as a unary JSON error (HTTP 429,
+# read back as CODE_UNAVAILABLE) instead of RESOURCE_EXHAUSTED.
 # Per-message streaming receive limits are future work.
 Server Message Size/**/client-stream/*
+Server Message Size/**/server-stream/*

--- a/conformance/known-failing-netty.txt
+++ b/conformance/known-failing-netty.txt
@@ -2,24 +2,32 @@
 # Entries follow https://github.com/connectrpc/conformance/blob/main/docs/configuring_and_running_tests.md
 #
 # Per-message (envelope) compression for streaming RPCs is not implemented yet
-# (see issue #190): handleClientStream rejects a non-identity
-# `Connect-Content-Encoding` and any compressed envelope frame with
-# CODE_UNIMPLEMENTED. The conformance config advertises COMPRESSION_GZIP for the
-# whole server, so the runner also exercises gzip against client-stream, where
-# every case fails the same way. Unary gzip is fully supported. The Timeouts
-# suite races the rejection against the deadline and is tracked in
-# known-flaky-netty.txt instead.
+# (see issue #190): the streaming handlers reject a non-identity
+# `Connect-Content-Encoding` with CODE_UNIMPLEMENTED. The conformance config
+# advertises COMPRESSION_GZIP for the whole server, so the runner also exercises
+# gzip against the streaming RPCs, where every case fails the same way. Unary
+# gzip is fully supported. The Timeouts suite races the rejection against the
+# deadline and is tracked in known-flaky-netty.txt instead.
 Basic/**/Compression:COMPRESSION_GZIP/**/client-stream/**
+Basic/**/Compression:COMPRESSION_GZIP/**/server-stream/**
 Connect to HTTP Code Mapping/**/Compression:COMPRESSION_GZIP/**/client-stream/**
+Connect to HTTP Code Mapping/**/Compression:COMPRESSION_GZIP/**/server-stream/**
 Deadline Propagation/**/Compression:COMPRESSION_GZIP/**/client-stream/**
+Deadline Propagation/**/Compression:COMPRESSION_GZIP/**/server-stream/**
 Duplicate Metadata/**/Compression:COMPRESSION_GZIP/**/client-stream/**
+Duplicate Metadata/**/Compression:COMPRESSION_GZIP/**/server-stream/**
 Errors/**/Compression:COMPRESSION_GZIP/**/client-stream/**
+Errors/**/Compression:COMPRESSION_GZIP/**/server-stream/**
+# The TLS Client Certs suite only defines a client-stream case, so there is no
+# server-stream counterpart to pin here.
 TLS Client Certs/**/Compression:COMPRESSION_GZIP/**/client-stream
 
 # `connectBodyLimit` enforces a whole-body byte cap, which equals a single
-# message for unary RPCs. Client-streaming needs a per-message receive limit
-# (and a streaming end-of-stream error frame): the whole-body cap both
-# over-rejects when individual messages are within the limit but their sum is
-# not, and surfaces the overflow as CODE_UNKNOWN instead of RESOURCE_EXHAUSTED.
+# message for unary RPCs. Streaming RPCs need a per-message receive limit (and a
+# streaming end-of-stream error frame): the whole-body cap also counts the 5 byte
+# envelope prefix, over-rejects when individual messages are within the limit but
+# their sum is not, and surfaces the overflow as a unary JSON error (HTTP 429,
+# read back as CODE_UNAVAILABLE) instead of RESOURCE_EXHAUSTED.
 # Per-message streaming receive limits are future work.
 Server Message Size/**/client-stream/*
+Server Message Size/**/server-stream/*

--- a/conformance/known-flaky-cio.txt
+++ b/conformance/known-flaky-cio.txt
@@ -2,9 +2,10 @@
 # Entries follow https://github.com/connectrpc/conformance/blob/main/docs/configuring_and_running_tests.md
 #
 # Per-message (envelope) compression for streaming RPCs is unimplemented
-# (see issue #190), so gzip client-stream RPCs are rejected with
+# (see issue #190), so gzip client-stream and server-stream RPCs are rejected with
 # CODE_UNIMPLEMENTED. The Timeouts suite expects CODE_DEADLINE_EXCEEDED; which
 # code the client observes depends on whether the server's rejection or the
 # (very short) deadline wins the race, so these cases are allowed — but not
 # required — to fail.
 Timeouts/**/Compression:COMPRESSION_GZIP/**/client-stream
+Timeouts/**/Compression:COMPRESSION_GZIP/**/server-stream

--- a/conformance/known-flaky-netty.txt
+++ b/conformance/known-flaky-netty.txt
@@ -2,9 +2,10 @@
 # Entries follow https://github.com/connectrpc/conformance/blob/main/docs/configuring_and_running_tests.md
 #
 # Per-message (envelope) compression for streaming RPCs is unimplemented
-# (see issue #190), so gzip client-stream RPCs are rejected with
+# (see issue #190), so gzip client-stream and server-stream RPCs are rejected with
 # CODE_UNIMPLEMENTED. The Timeouts suite expects CODE_DEADLINE_EXCEEDED; which
 # code the client observes depends on whether the server's rejection or the
 # (very short) deadline wins the race, so these cases are allowed — but not
 # required — to fail.
 Timeouts/**/Compression:COMPRESSION_GZIP/**/client-stream
+Timeouts/**/Compression:COMPRESSION_GZIP/**/server-stream

--- a/conformance/src/main/kotlin/io/github/ichizero/connect/ktor/conformance/ConformanceApp.kt
+++ b/conformance/src/main/kotlin/io/github/ichizero/connect/ktor/conformance/ConformanceApp.kt
@@ -3,6 +3,7 @@ package io.github.ichizero.connect.ktor.conformance
 import com.connectrpc.conformance.v1.ClientStreamRequest
 import com.connectrpc.conformance.v1.ConformanceServiceHandlerInterface
 import com.connectrpc.conformance.v1.IdempotentUnaryRequest
+import com.connectrpc.conformance.v1.ServerStreamRequest
 import com.connectrpc.conformance.v1.UnaryRequest
 import com.connectrpc.conformance.v1.UnimplementedRequest
 import com.connectrpc.conformance.v1.conformanceService
@@ -41,6 +42,7 @@ internal val conformanceTypeRegistry: TypeRegistry = TypeRegistry.newBuilder()
     .add(IdempotentUnaryRequest.getDescriptor())
     .add(UnimplementedRequest.getDescriptor())
     .add(ClientStreamRequest.getDescriptor())
+    .add(ServerStreamRequest.getDescriptor())
     .build()
 
 /**

--- a/conformance/src/main/kotlin/io/github/ichizero/connect/ktor/conformance/ConformanceServiceImpl.kt
+++ b/conformance/src/main/kotlin/io/github/ichizero/connect/ktor/conformance/ConformanceServiceImpl.kt
@@ -10,6 +10,8 @@ import com.connectrpc.conformance.v1.ConformancePayload
 import com.connectrpc.conformance.v1.ConformanceServiceHandlerInterface
 import com.connectrpc.conformance.v1.IdempotentUnaryRequest
 import com.connectrpc.conformance.v1.IdempotentUnaryResponse
+import com.connectrpc.conformance.v1.ServerStreamRequest
+import com.connectrpc.conformance.v1.ServerStreamResponse
 import com.connectrpc.conformance.v1.UnaryRequest
 import com.connectrpc.conformance.v1.UnaryResponse
 import com.connectrpc.conformance.v1.UnaryResponseDefinition
@@ -17,11 +19,14 @@ import com.connectrpc.conformance.v1.UnimplementedRequest
 import com.connectrpc.conformance.v1.UnimplementedResponse
 import com.google.protobuf.Message
 import io.github.ichizero.connect.ktor.ConnectGetQueryParamsKey
+import io.github.ichizero.connect.ktor.streaming.connectResponseTrailers
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.request.ApplicationRequest
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.toList
 import okio.ByteString.Companion.toByteString
+import com.connectrpc.conformance.v1.Error as ConformanceError
 import com.connectrpc.conformance.v1.Header as ConformanceHeader
 import com.google.protobuf.Any as ProtoAny
 
@@ -72,7 +77,7 @@ class ConformanceServiceImpl : ConformanceServiceHandlerInterface {
             ?.takeIf { it.hasResponseDefinition() }
             ?.responseDefinition
 
-        val requestInfo = buildClientStreamRequestInfo(call.request, collected)
+        val requestInfo = buildStreamRequestInfo(call.request, collected)
 
         val headers = responseDefinition?.responseHeadersList.toMultimap()
         val trailers = responseDefinition?.responseTrailersList.toMultimap()
@@ -82,22 +87,7 @@ class ConformanceServiceImpl : ConformanceServiceHandlerInterface {
         }
 
         if (responseDefinition != null && responseDefinition.hasError()) {
-            val err = responseDefinition.error
-            val cause = ConnectException(
-                code = connectCodeFor(err.code.number),
-                message = if (err.hasMessage()) err.message else null,
-            ).withErrorDetails(
-                errorParser = NoopErrorDetailParser,
-                details = err.detailsList.map {
-                    ConnectErrorDetail(
-                        type = it.typeUrl.substringAfterLast('/'),
-                        payload = it.value.toByteArray().toByteString(),
-                    )
-                } + ConnectErrorDetail(
-                    type = requestInfo.descriptorForType.fullName,
-                    payload = requestInfo.toByteArray().toByteString(),
-                ),
-            )
+            val cause = responseDefinition.error.toConnectException(requestInfo)
             return ResponseMessage.Failure(cause = cause, headers = headers, trailers = trailers)
         }
 
@@ -119,6 +109,49 @@ class ConformanceServiceImpl : ConformanceServiceHandlerInterface {
         )
     }
 
+    override suspend fun serverStream(
+        request: ServerStreamRequest,
+        call: ApplicationCall,
+    ): Flow<ServerStreamResponse> {
+        val responseDefinition = if (request.hasResponseDefinition()) request.responseDefinition else null
+
+        // Headers go out with the response head, trailers with the end-stream frame. Both are set
+        // before the flow is collected so they are observable even when the producer is slow or the
+        // stream ends in an error.
+        responseDefinition?.responseHeadersList?.forEach { header ->
+            header.valueList.forEach { call.response.headers.append(header.name, it, safeOnly = false) }
+        }
+        responseDefinition?.responseTrailersList?.forEach { header ->
+            call.connectResponseTrailers().appendAll(header.name, header.valueList)
+        }
+
+        val requestInfo = buildStreamRequestInfo(call.request, listOf(request))
+
+        return flow {
+            if (responseDefinition == null) return@flow
+
+            var sent = 0
+            for (data in responseDefinition.responseDataList) {
+                if (responseDefinition.responseDelayMs > 0) {
+                    kotlinx.coroutines.delay(responseDefinition.responseDelayMs.toLong())
+                }
+                val payload = ConformancePayload.newBuilder()
+                    .setData(data)
+                    // Nothing in the request info changes after the first response, so the
+                    // conformance spec only expects it on the first message.
+                    .apply { if (sent == 0) setRequestInfo(requestInfo) }
+                    .build()
+                emit(ServerStreamResponse.newBuilder().setPayload(payload).build())
+                sent++
+            }
+
+            if (responseDefinition.hasError()) {
+                // The request info can only be reported through the error when no response carried it.
+                throw responseDefinition.error.toConnectException(requestInfo.takeIf { sent == 0 })
+            }
+        }
+    }
+
     private suspend fun <Resp : Message> handleUnary(
         responseDefinition: UnaryResponseDefinition?,
         echoMessage: Message,
@@ -135,22 +168,7 @@ class ConformanceServiceImpl : ConformanceServiceHandlerInterface {
         }
 
         if (responseDefinition != null && responseDefinition.hasError()) {
-            val err = responseDefinition.error
-            val cause = ConnectException(
-                code = connectCodeFor(err.code.number),
-                message = if (err.hasMessage()) err.message else null,
-            ).withErrorDetails(
-                errorParser = NoopErrorDetailParser,
-                details = err.detailsList.map {
-                    ConnectErrorDetail(
-                        type = it.typeUrl.substringAfterLast('/'),
-                        payload = it.value.toByteArray().toByteString(),
-                    )
-                } + ConnectErrorDetail(
-                    type = requestInfo.descriptorForType.fullName,
-                    payload = requestInfo.toByteArray().toByteString(),
-                ),
-            )
+            val cause = responseDefinition.error.toConnectException(requestInfo)
             return ResponseMessage.Failure(cause = cause, headers = headers, trailers = trailers)
         }
 
@@ -194,7 +212,7 @@ private fun buildRequestInfo(call: ApplicationCall, echoMessage: Message): Confo
     return builder.build()
 }
 
-private fun buildClientStreamRequestInfo(
+private fun buildStreamRequestInfo(
     request: ApplicationRequest,
     echoMessages: List<Message>,
 ): ConformancePayload.RequestInfo {
@@ -223,6 +241,33 @@ private fun List<ConformanceHeader>?.toMultimap(): Map<String, List<String>> {
     }
     return map
 }
+
+/**
+ * Build the Connect error the conformance definition asks for. [requestInfo], when non-null, is
+ * appended to the error details — the conformance client reads it back from there whenever no
+ * response message could carry it.
+ */
+private fun ConformanceError.toConnectException(
+    requestInfo: ConformancePayload.RequestInfo?,
+): ConnectException = ConnectException(
+    code = connectCodeFor(code.number),
+    message = if (hasMessage()) message else null,
+).withErrorDetails(
+    errorParser = NoopErrorDetailParser,
+    details = detailsList.map {
+        ConnectErrorDetail(
+            type = it.typeUrl.substringAfterLast('/'),
+            payload = it.value.toByteArray().toByteString(),
+        )
+    } + listOfNotNull(
+        requestInfo?.let {
+            ConnectErrorDetail(
+                type = it.descriptorForType.fullName,
+                payload = it.toByteArray().toByteString(),
+            )
+        },
+    ),
+)
 
 private fun connectCodeFor(protoNumber: Int): Code =
     Code.entries.firstOrNull { it.value == protoNumber } ?: Code.UNKNOWN

--- a/library/detekt-baseline.xml
+++ b/library/detekt-baseline.xml
@@ -24,5 +24,6 @@
     <ID>ThrowsCount:HandleClientStream.kt$@PublishedApi internal suspend fun &lt;Req : Any, Res : Any&gt; handleClientStreamCall( call: ApplicationCall, maxMessageSize: Int, reqClass: KClass&lt;Req&gt;, resClass: KClass&lt;Res&gt;, handlerFunc: suspend (Flow&lt;Req&gt;, ApplicationCall) -&gt; ResponseMessage&lt;Res&gt;, )</ID>
     <ID>TooGenericExceptionCaught:HandleClientStream.kt$e: Throwable</ID>
     <ID>TooGenericExceptionCaught:HandleGet.kt$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:HandleServerStream.kt$e: Throwable</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/library/detekt-baseline.xml
+++ b/library/detekt-baseline.xml
@@ -24,6 +24,6 @@
     <ID>ThrowsCount:HandleClientStream.kt$@PublishedApi internal suspend fun &lt;Req : Any, Res : Any&gt; handleClientStreamCall( call: ApplicationCall, maxMessageSize: Int, reqClass: KClass&lt;Req&gt;, resClass: KClass&lt;Res&gt;, handlerFunc: suspend (Flow&lt;Req&gt;, ApplicationCall) -&gt; ResponseMessage&lt;Res&gt;, )</ID>
     <ID>TooGenericExceptionCaught:HandleClientStream.kt$e: Throwable</ID>
     <ID>TooGenericExceptionCaught:HandleGet.kt$e: Exception</ID>
-    <ID>TooGenericExceptionCaught:HandleServerStream.kt$e: Throwable</ID>
+    <ID>TooGenericExceptionCaught:HandleServerStream.kt$e: Exception</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/library/proto/stricteliza/v1/strict_eliza.proto
+++ b/library/proto/stricteliza/v1/strict_eliza.proto
@@ -11,6 +11,9 @@ service StrictElizaService {
 
     // Upload is a client-streaming RPC used to exercise envelope-framed request bodies.
     rpc Upload(stream UploadRequest) returns (UploadResponse);
+
+    // Countdown is a server-streaming RPC used to exercise envelope-framed response bodies.
+    rpc Countdown(CountdownRequest) returns (stream CountdownResponse);
 }
 
 message SayRequest {
@@ -29,4 +32,12 @@ message UploadRequest {
 message UploadResponse {
     int64 total_chars = 1;
     int64 chunk_count = 2;
+}
+
+message CountdownRequest {
+    int32 from = 1;
+}
+
+message CountdownResponse {
+    int32 value = 1;
 }

--- a/library/src/main/kotlin/io/github/ichizero/connect/ktor/streaming/EndStreamResponse.kt
+++ b/library/src/main/kotlin/io/github/ichizero/connect/ktor/streaming/EndStreamResponse.kt
@@ -1,0 +1,46 @@
+package io.github.ichizero.connect.ktor.streaming
+
+import com.connectrpc.ConnectException
+import io.ktor.http.ContentType
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.response.respondBytesWriter
+import io.ktor.utils.io.ByteWriteChannel
+
+/**
+ * Write the terminating Connect end-stream frame (`flags = 2`) carrying the response trailers and,
+ * when the RPC failed, the error. The payload is always JSON regardless of the message codec.
+ */
+internal suspend fun ByteWriteChannel.writeEndStream(
+    error: ConnectException?,
+    trailers: Map<String, List<String>>,
+) {
+    val payload = buildEndStreamPayload(trailers = trailers, error = error)
+    writeEnvelopeFrame(EnvelopeFrame(flags = EnvelopeFlags.END_STREAM, payload = payload))
+}
+
+/**
+ * Respond with a body that consists of nothing but an end-stream frame. Used for failures observed
+ * before any data frame could be produced (header validation, codec resolution, request framing).
+ */
+internal suspend fun respondEndStreamOnly(
+    call: ApplicationCall,
+    contentType: ContentType,
+    error: ConnectException,
+    trailers: Map<String, List<String>>,
+) {
+    call.respondBytesWriter(contentType = contentType) {
+        writeEndStream(error = error, trailers = trailers)
+    }
+}
+
+/**
+ * Pick the response Content-Type when the request couldn't even be classified to a codec —
+ * echo the request type if it was a recognized streaming type, else fall back to JSON. The
+ * end-frame payload itself is always JSON, but the Content-Type drives client-side framing.
+ */
+internal fun bestEffortResponseContentType(requestContentType: ContentType?): ContentType = when {
+    requestContentType == null -> ConnectStreamingContentType.Json
+    requestContentType.match(ConnectStreamingContentType.Proto) -> ConnectStreamingContentType.Proto
+    requestContentType.match(ConnectStreamingContentType.Json) -> ConnectStreamingContentType.Json
+    else -> ConnectStreamingContentType.Json
+}

--- a/library/src/main/kotlin/io/github/ichizero/connect/ktor/streaming/HandleClientStream.kt
+++ b/library/src/main/kotlin/io/github/ichizero/connect/ktor/streaming/HandleClientStream.kt
@@ -3,7 +3,6 @@ package io.github.ichizero.connect.ktor.streaming
 import com.connectrpc.Code
 import com.connectrpc.ConnectException
 import com.connectrpc.ResponseMessage
-import io.ktor.http.ContentType
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.application.application
 import io.ktor.server.http.content.suppressCompression
@@ -12,7 +11,6 @@ import io.ktor.server.request.contentType
 import io.ktor.server.request.receiveChannel
 import io.ktor.server.response.respondBytesWriter
 import io.ktor.server.routing.RoutingContext
-import io.ktor.utils.io.ByteWriteChannel
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filter
@@ -244,35 +242,4 @@ private fun writeResponseHeaders(call: ApplicationCall, headers: Map<String, Lis
             call.response.headers.append(name, v, safeOnly = false)
         }
     }
-}
-
-private suspend fun ByteWriteChannel.writeEndStream(
-    error: ConnectException?,
-    trailers: Map<String, List<String>>,
-) {
-    val payload = buildEndStreamPayload(trailers = trailers, error = error)
-    writeEnvelopeFrame(EnvelopeFrame(flags = EnvelopeFlags.END_STREAM, payload = payload))
-}
-
-private suspend fun respondEndStreamOnly(
-    call: ApplicationCall,
-    contentType: ContentType,
-    error: ConnectException,
-    trailers: Map<String, List<String>>,
-) {
-    call.respondBytesWriter(contentType = contentType) {
-        writeEndStream(error = error, trailers = trailers)
-    }
-}
-
-/**
- * Pick the response Content-Type when the request couldn't even be classified to a codec —
- * echo the request type if it was a recognized streaming type, else fall back to JSON. The
- * end-frame payload itself is always JSON, but the Content-Type drives client-side framing.
- */
-private fun bestEffortResponseContentType(requestContentType: ContentType?): ContentType = when {
-    requestContentType == null -> ConnectStreamingContentType.Json
-    requestContentType.match(ConnectStreamingContentType.Proto) -> ConnectStreamingContentType.Proto
-    requestContentType.match(ConnectStreamingContentType.Json) -> ConnectStreamingContentType.Json
-    else -> ConnectStreamingContentType.Json
 }

--- a/library/src/main/kotlin/io/github/ichizero/connect/ktor/streaming/HandleServerStream.kt
+++ b/library/src/main/kotlin/io/github/ichizero/connect/ktor/streaming/HandleServerStream.kt
@@ -1,0 +1,269 @@
+package io.github.ichizero.connect.ktor.streaming
+
+import com.connectrpc.Code
+import com.connectrpc.ConnectException
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.application.application
+import io.ktor.server.http.content.suppressCompression
+import io.ktor.server.http.content.suppressDecompression
+import io.ktor.server.request.contentType
+import io.ktor.server.request.receiveChannel
+import io.ktor.server.response.respondBytesWriter
+import io.ktor.server.routing.RoutingContext
+import io.ktor.utils.io.ByteWriteChannel
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.withTimeout
+import kotlinx.io.IOException
+import kotlin.reflect.KClass
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.TimeSource
+
+/**
+ * Handle a Connect protocol server-streaming RPC on a Ktor route.
+ *
+ * Wire behavior:
+ * - Request body is a single Connect envelope frame holding the request message. A body with no
+ *   data frame, or with more than one, is rejected with [Code.UNIMPLEMENTED] — the same shape
+ *   connect-go's server-stream handler produces.
+ * - The handler returns a cold [Flow] of [Res]. Each emitted message is written as one data frame
+ *   and flushed, so the client observes messages as the producer emits them.
+ * - The stream terminates with an end-stream frame carrying the trailers accumulated via
+ *   [connectResponseTrailers] and, when the flow failed, the error. A [ConnectException] thrown by
+ *   the flow supplies both the error and (through its `metadata`) extra trailers.
+ * - HTTP status is always 200; streaming errors are conveyed in the end-stream payload.
+ *
+ * Response headers are set by the handler on `call.response.headers` before the flow is collected,
+ * and the response head is flushed ahead of the first message so a slow producer never keeps the
+ * client waiting on headers.
+ *
+ * Cancellation propagates: when the client disconnects, the collector of the handler's flow is
+ * cancelled instead of the failure being converted into an end-stream frame nobody will read.
+ *
+ * Use via the generated route binding:
+ * ```
+ * post<Procedures.Tail>(handleServerStream(handler::tail))
+ * ```
+ */
+inline fun <Resource : Any, reified Req : Any, reified Res : Any> handleServerStream(
+    noinline handlerFunc: suspend (request: Req, call: ApplicationCall) -> Flow<Res>,
+    maxMessageSize: Int = DEFAULT_MAX_MESSAGE_SIZE,
+): suspend RoutingContext.(Resource) -> Unit {
+    val reqClass = Req::class
+    val resClass = Res::class
+    return { _ ->
+        handleServerStreamCall(
+            call = call,
+            maxMessageSize = maxMessageSize,
+            reqClass = reqClass,
+            resClass = resClass,
+            handlerFunc = handlerFunc,
+        )
+    }
+}
+
+@PublishedApi
+internal suspend fun <Req : Any, Res : Any> handleServerStreamCall(
+    call: ApplicationCall,
+    maxMessageSize: Int,
+    reqClass: KClass<Req>,
+    resClass: KClass<Res>,
+    handlerFunc: suspend (Req, ApplicationCall) -> Flow<Res>,
+) {
+    // Connect streaming bodies are length-prefixed (LPM). Any user-installed Ktor Compression
+    // plugin would otherwise double-encode the body on output or attempt to decode the request
+    // before our framer sees it. Per-message compression negotiated via `Connect-Content-Encoding`
+    // is the framer's responsibility (currently unimplemented; see issue #190).
+    call.suppressCompression()
+    call.suppressDecompression()
+
+    val requestContentType = call.request.contentType()
+
+    // Phase 1: validate headers and resolve codec before any response writing.
+    val codec: StreamingCodec = try {
+        call.validateConnectStreamingHeaders()
+        resolveStreamingCodec(call.application, requestContentType)
+    } catch (e: ConnectException) {
+        respondEndStreamOnly(
+            call = call,
+            contentType = bestEffortResponseContentType(requestContentType),
+            error = e,
+            trailers = emptyMap(),
+        )
+        return
+    }
+
+    val deadline = call.connectTimeoutMs()?.let(::StreamDeadline)
+
+    // Phase 2: read the single request message and let the handler produce its flow. Failures here
+    // happen before any data frame exists, so they render as an end-stream-only body.
+    val started = call.startStream(codec, reqClass, maxMessageSize, deadline, handlerFunc)
+
+    // Phase 3: stream the messages. The response head is committed by respondBytesWriter; flushing
+    // before the first message pushes it to the client even when the producer is slow, mirroring
+    // the empty send connect-go issues at the start of a server stream.
+    when (started) {
+        is StartedStream.Failed -> call.respondEndStream(codec, started.error)
+
+        is StartedStream.Ready -> call.respondBytesWriter(contentType = codec.streamingContentType) {
+            flush()
+            val error = writeResponseMessages(codec, resClass, started.responses, deadline)
+            writeEndStream(
+                error = error,
+                trailers = mergeTrailers(call.connectResponseTrailersSnapshot(), error?.metadata.orEmpty()),
+            )
+        }
+    }
+}
+
+private sealed interface StartedStream<out R : Any> {
+    data class Ready<R : Any>(val responses: Flow<R>) : StartedStream<R>
+
+    data class Failed(val error: ConnectException) : StartedStream<Nothing>
+}
+
+private suspend fun <Req : Any, Res : Any> ApplicationCall.startStream(
+    codec: StreamingCodec,
+    reqClass: KClass<Req>,
+    maxMessageSize: Int,
+    deadline: StreamDeadline?,
+    handlerFunc: suspend (Req, ApplicationCall) -> Flow<Res>,
+): StartedStream<Res> = try {
+    StartedStream.Ready(
+        withDeadline(deadline) {
+            val request = codec.decodeRequest(receiveRequestFrame(maxMessageSize), reqClass)
+            handlerFunc(request, this)
+        },
+    )
+} catch (e: TimeoutCancellationException) {
+    StartedStream.Failed(deadlineExceeded(e))
+} catch (e: CancellationException) {
+    throw e
+} catch (e: ConnectException) {
+    StartedStream.Failed(e)
+} catch (e: Throwable) {
+    StartedStream.Failed(ConnectException(code = Code.UNKNOWN, message = e.message, exception = e))
+}
+
+/**
+ * Read the one envelope frame a server-streaming request carries.
+ *
+ * Both "no message" and "more than one message" are protocol violations for this stream type;
+ * connect-go reports them as [Code.UNIMPLEMENTED] and the conformance suite pins that expectation.
+ * Reading a second frame before invoking the handler is what makes the second case detectable.
+ */
+private suspend fun ApplicationCall.receiveRequestFrame(maxMessageSize: Int): EnvelopeFrame {
+    val frames = receiveChannel()
+        .readEnvelopeFrames(maxMessageSize)
+        .filter { !it.isEndStream }
+        .take(2)
+        .toList()
+
+    val violation = when {
+        frames.isEmpty() -> "unary request has zero messages"
+        frames.size > 1 -> "unary request has multiple messages"
+        else -> null
+    }
+    if (violation != null) {
+        throw ConnectException(code = Code.UNIMPLEMENTED, message = violation)
+    }
+
+    val frame = frames.first()
+    if (frame.isCompressed) {
+        // A compressed frame without negotiated compression is a protocol error rather than a
+        // missing feature — connect-go's envelopeReader reports it the same way.
+        throw ConnectException(
+            code = Code.INTERNAL_ERROR,
+            message = "protocol error: sent compressed message without connect-content-encoding",
+        )
+    }
+    return frame
+}
+
+private fun <Req : Any> StreamingCodec.decodeRequest(frame: EnvelopeFrame, reqClass: KClass<Req>): Req = try {
+    deserialize(frame.payload, reqClass)
+} catch (e: ConnectException) {
+    throw e
+} catch (e: Throwable) {
+    throw ConnectException(
+        code = Code.INVALID_ARGUMENT,
+        message = "failed to decode request frame: ${e.message}",
+        exception = e,
+    )
+}
+
+/**
+ * Collect [responses] into data frames, returning the error that terminated the stream (or null on
+ * normal completion) so the caller can put it in the end-stream frame.
+ *
+ * Cancellation and broken response channels are rethrown rather than converted: the client is gone,
+ * so there is nobody left to read an end-stream frame, and swallowing the cancellation would leave
+ * the flow's collector — and whatever resources it holds — running.
+ */
+private suspend fun <Res : Any> ByteWriteChannel.writeResponseMessages(
+    codec: StreamingCodec,
+    resClass: KClass<Res>,
+    responses: Flow<Res>,
+    deadline: StreamDeadline?,
+): ConnectException? = try {
+    withDeadline(deadline) {
+        responses.collect { message ->
+            writeEnvelopeFrame(EnvelopeFrame(flags = 0, payload = codec.encodeResponse(message, resClass)))
+        }
+    }
+    null
+} catch (e: TimeoutCancellationException) {
+    deadlineExceeded(e)
+} catch (e: CancellationException) {
+    throw e
+} catch (e: IOException) {
+    throw e
+} catch (e: ConnectException) {
+    e
+} catch (e: Throwable) {
+    ConnectException(code = Code.UNKNOWN, message = e.message, exception = e)
+}
+
+private fun <Res : Any> StreamingCodec.encodeResponse(message: Res, resClass: KClass<Res>): ByteArray = try {
+    serialize(message, resClass)
+} catch (e: Throwable) {
+    throw ConnectException(
+        code = Code.INTERNAL_ERROR,
+        message = "failed to encode response: ${e.message}",
+        exception = e,
+    )
+}
+
+private suspend fun ApplicationCall.respondEndStream(codec: StreamingCodec, error: ConnectException) {
+    respondEndStreamOnly(
+        call = this,
+        contentType = codec.streamingContentType,
+        error = error,
+        trailers = mergeTrailers(connectResponseTrailersSnapshot(), error.metadata),
+    )
+}
+
+private fun deadlineExceeded(cause: Throwable): ConnectException = ConnectException(
+    code = Code.DEADLINE_EXCEEDED,
+    message = "deadline exceeded",
+    exception = cause,
+)
+
+/**
+ * The `Connect-Timeout-Ms` budget, shared by the request-read and response-streaming phases so both
+ * are bounded by the same deadline instead of each getting a fresh one.
+ */
+private class StreamDeadline(timeoutMs: Long) {
+    private val start = TimeSource.Monotonic.markNow()
+    private val budget = timeoutMs.milliseconds
+
+    fun remaining(): Duration = budget - start.elapsedNow()
+}
+
+private suspend fun <T> withDeadline(deadline: StreamDeadline?, block: suspend () -> T): T =
+    if (deadline == null) block() else withTimeout(deadline.remaining()) { block() }

--- a/library/src/main/kotlin/io/github/ichizero/connect/ktor/streaming/HandleServerStream.kt
+++ b/library/src/main/kotlin/io/github/ichizero/connect/ktor/streaming/HandleServerStream.kt
@@ -2,6 +2,7 @@ package io.github.ichizero.connect.ktor.streaming
 
 import com.connectrpc.Code
 import com.connectrpc.ConnectException
+import io.github.ichizero.ktor.protovalidate.validateStreamingRequest
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.application.application
 import io.ktor.server.http.content.suppressCompression
@@ -14,6 +15,7 @@ import io.ktor.utils.io.ByteWriteChannel
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
@@ -137,6 +139,7 @@ private suspend fun <Req : Any, Res : Any> ApplicationCall.startStream(
     StartedStream.Ready(
         withDeadline(deadline) {
             val request = codec.decodeRequest(receiveRequestFrame(maxMessageSize), reqClass)
+            validateStreamingRequest(request)
             handlerFunc(request, this)
         },
     )
@@ -146,7 +149,7 @@ private suspend fun <Req : Any, Res : Any> ApplicationCall.startStream(
     throw e
 } catch (e: ConnectException) {
     StartedStream.Failed(e)
-} catch (e: Throwable) {
+} catch (e: Exception) {
     StartedStream.Failed(ConnectException(code = Code.UNKNOWN, message = e.message, exception = e))
 }
 
@@ -189,7 +192,7 @@ private fun <Req : Any> StreamingCodec.decodeRequest(frame: EnvelopeFrame, reqCl
     deserialize(frame.payload, reqClass)
 } catch (e: ConnectException) {
     throw e
-} catch (e: Throwable) {
+} catch (e: Exception) {
     throw ConnectException(
         code = Code.INVALID_ARGUMENT,
         message = "failed to decode request frame: ${e.message}",
@@ -211,12 +214,21 @@ private suspend fun <Res : Any> ByteWriteChannel.writeResponseMessages(
     responses: Flow<Res>,
     deadline: StreamDeadline?,
 ): ConnectException? = try {
+    var producerError: ConnectException? = null
     withDeadline(deadline) {
-        responses.collect { message ->
+        // Flow.catch only handles upstream failures, leaving response-channel failures to propagate.
+        responses.catch { cause ->
+            producerError = when (cause) {
+                is CancellationException -> throw cause
+                is ConnectException -> cause
+                is Exception -> ConnectException(code = Code.UNKNOWN, message = cause.message, exception = cause)
+                else -> throw cause
+            }
+        }.collect { message ->
             writeEnvelopeFrame(EnvelopeFrame(flags = 0, payload = codec.encodeResponse(message, resClass)))
         }
     }
-    null
+    producerError
 } catch (e: TimeoutCancellationException) {
     deadlineExceeded(e)
 } catch (e: CancellationException) {
@@ -225,13 +237,13 @@ private suspend fun <Res : Any> ByteWriteChannel.writeResponseMessages(
     throw e
 } catch (e: ConnectException) {
     e
-} catch (e: Throwable) {
+} catch (e: Exception) {
     ConnectException(code = Code.UNKNOWN, message = e.message, exception = e)
 }
 
 private fun <Res : Any> StreamingCodec.encodeResponse(message: Res, resClass: KClass<Res>): ByteArray = try {
     serialize(message, resClass)
-} catch (e: Throwable) {
+} catch (e: Exception) {
     throw ConnectException(
         code = Code.INTERNAL_ERROR,
         message = "failed to encode response: ${e.message}",

--- a/library/src/main/kotlin/io/github/ichizero/connect/ktor/streaming/HandleServerStream.kt
+++ b/library/src/main/kotlin/io/github/ichizero/connect/ktor/streaming/HandleServerStream.kt
@@ -27,25 +27,14 @@ import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.TimeSource
 
 /**
- * Handle a Connect protocol server-streaming RPC on a Ktor route.
+ * Handle a Connect server-streaming RPC with one request envelope and a cold [Flow] of responses.
+ * Zero or multiple request messages are rejected with [Code.UNIMPLEMENTED]. Each response is
+ * flushed as a data frame, followed by an end-stream frame containing trailers and any RPC error.
+ * Streaming responses use HTTP 200; RPC errors are carried in the end-stream payload.
  *
- * Wire behavior:
- * - Request body is a single Connect envelope frame holding the request message. A body with no
- *   data frame, or with more than one, is rejected with [Code.UNIMPLEMENTED] — the same shape
- *   connect-go's server-stream handler produces.
- * - The handler returns a cold [Flow] of [Res]. Each emitted message is written as one data frame
- *   and flushed, so the client observes messages as the producer emits them.
- * - The stream terminates with an end-stream frame carrying the trailers accumulated via
- *   [connectResponseTrailers] and, when the flow failed, the error. A [ConnectException] thrown by
- *   the flow supplies both the error and (through its `metadata`) extra trailers.
- * - HTTP status is always 200; streaming errors are conveyed in the end-stream payload.
- *
- * Response headers are set by the handler on `call.response.headers` before the flow is collected,
- * and the response head is flushed ahead of the first message so a slow producer never keeps the
- * client waiting on headers.
- *
- * Cancellation propagates: when the client disconnects, the collector of the handler's flow is
- * cancelled instead of the failure being converted into an end-stream frame nobody will read.
+ * Set response headers on `call.response.headers` before returning the flow. Trailers can be
+ * appended through [connectResponseTrailers] until collection ends; [ConnectException.metadata]
+ * is merged into them on failure. Cancellation, broken response channels, and JVM errors propagate.
  *
  * Use via the generated route binding:
  * ```
@@ -77,16 +66,13 @@ internal suspend fun <Req : Any, Res : Any> handleServerStreamCall(
     resClass: KClass<Res>,
     handlerFunc: suspend (Req, ApplicationCall) -> Flow<Res>,
 ) {
-    // Connect streaming bodies are length-prefixed (LPM). Any user-installed Ktor Compression
-    // plugin would otherwise double-encode the body on output or attempt to decode the request
-    // before our framer sees it. Per-message compression negotiated via `Connect-Content-Encoding`
-    // is the framer's responsibility (currently unimplemented; see issue #190).
+    // Envelope framing owns compression; HTTP compression plugins must not transform these bodies.
     call.suppressCompression()
     call.suppressDecompression()
 
     val requestContentType = call.request.contentType()
 
-    // Phase 1: validate headers and resolve codec before any response writing.
+    // Resolve the codec before opening the response writer so header failures can use a fallback type.
     val codec: StreamingCodec = try {
         call.validateConnectStreamingHeaders()
         resolveStreamingCodec(call.application, requestContentType)
@@ -102,17 +88,13 @@ internal suspend fun <Req : Any, Res : Any> handleServerStreamCall(
 
     val deadline = call.connectTimeoutMs()?.let(::StreamDeadline)
 
-    // Phase 2: read the single request message and let the handler produce its flow. Failures here
-    // happen before any data frame exists, so they render as an end-stream-only body.
     val started = call.startStream(codec, reqClass, maxMessageSize, deadline, handlerFunc)
 
-    // Phase 3: stream the messages. The response head is committed by respondBytesWriter; flushing
-    // before the first message pushes it to the client even when the producer is slow, mirroring
-    // the empty send connect-go issues at the start of a server stream.
     when (started) {
         is StartedStream.Failed -> call.respondEndStream(codec, started.error)
 
         is StartedStream.Ready -> call.respondBytesWriter(contentType = codec.streamingContentType) {
+            // Send headers before collection so a slow producer does not delay the response head.
             flush()
             val error = writeResponseMessages(codec, resClass, started.responses, deadline)
             writeEndStream(
@@ -153,13 +135,8 @@ private suspend fun <Req : Any, Res : Any> ApplicationCall.startStream(
     StartedStream.Failed(ConnectException(code = Code.UNKNOWN, message = e.message, exception = e))
 }
 
-/**
- * Read the one envelope frame a server-streaming request carries.
- *
- * Both "no message" and "more than one message" are protocol violations for this stream type;
- * connect-go reports them as [Code.UNIMPLEMENTED] and the conformance suite pins that expectation.
- * Reading a second frame before invoking the handler is what makes the second case detectable.
- */
+// Read up to two data frames to distinguish missing and extra messages, matching connect-go's
+// UNIMPLEMENTED response for these protocol violations.
 private suspend fun ApplicationCall.receiveRequestFrame(maxMessageSize: Int): EnvelopeFrame {
     val frames = receiveChannel()
         .readEnvelopeFrames(maxMessageSize)
@@ -200,14 +177,7 @@ private fun <Req : Any> StreamingCodec.decodeRequest(frame: EnvelopeFrame, reqCl
     )
 }
 
-/**
- * Collect [responses] into data frames, returning the error that terminated the stream (or null on
- * normal completion) so the caller can put it in the end-stream frame.
- *
- * Cancellation and broken response channels are rethrown rather than converted: the client is gone,
- * so there is nobody left to read an end-stream frame, and swallowing the cancellation would leave
- * the flow's collector — and whatever resources it holds — running.
- */
+/** Return the terminating RPC error, or null on successful collection. */
 private suspend fun <Res : Any> ByteWriteChannel.writeResponseMessages(
     codec: StreamingCodec,
     resClass: KClass<Res>,

--- a/library/src/main/kotlin/io/github/ichizero/connect/ktor/streaming/StreamingTrailers.kt
+++ b/library/src/main/kotlin/io/github/ichizero/connect/ktor/streaming/StreamingTrailers.kt
@@ -1,0 +1,58 @@
+package io.github.ichizero.connect.ktor.streaming
+
+import io.ktor.http.HeadersBuilder
+import io.ktor.server.application.ApplicationCall
+import io.ktor.util.AttributeKey
+import io.ktor.util.toMap
+
+private val ConnectResponseTrailersKey: AttributeKey<HeadersBuilder> =
+    AttributeKey("io.github.ichizero.connect.ktor.streaming.ConnectResponseTrailers")
+
+/**
+ * Trailers to send in the end-stream frame of a Connect streaming response.
+ *
+ * Streaming RPCs carry their trailers inside the terminating envelope frame (`metadata`), not as
+ * HTTP headers, so they cannot be set through [io.ktor.server.response.ApplicationResponse.headers].
+ * A server-streaming handler returns a `Flow`, which has no slot for them either — hence this
+ * call-scoped builder.
+ *
+ * Values are read once, when the end-stream frame is written, so a handler may append to it either
+ * before returning the flow or while the flow is being collected. Keys are lowercased on the wire
+ * per the Connect protocol.
+ *
+ * ```
+ * override suspend fun tail(request: TailRequest, call: ApplicationCall): Flow<TailResponse> {
+ *     call.response.headers.append("x-stream-id", id)          // HTTP response header
+ *     call.connectResponseTrailers().append("x-record-count", count.toString()) // end-stream frame
+ *     return flow { ... }
+ * }
+ * ```
+ */
+fun ApplicationCall.connectResponseTrailers(): HeadersBuilder =
+    attributes.computeIfAbsent(ConnectResponseTrailersKey) { HeadersBuilder() }
+
+/**
+ * Snapshot of the trailers accumulated via [connectResponseTrailers], or an empty map when the
+ * handler never touched them.
+ */
+internal fun ApplicationCall.connectResponseTrailersSnapshot(): Map<String, List<String>> =
+    attributes.getOrNull(ConnectResponseTrailersKey)?.build()?.toMap() ?: emptyMap()
+
+/**
+ * Merge end-stream trailers, concatenating values that collide on the same key so nothing is
+ * dropped. Keys are lowercased later, when the end-stream payload is built.
+ */
+internal fun mergeTrailers(
+    trailers: Map<String, List<String>>,
+    extra: Map<String, List<String>>,
+): Map<String, List<String>> = when {
+    extra.isEmpty() -> trailers
+
+    trailers.isEmpty() -> extra
+
+    else -> LinkedHashMap(trailers).apply {
+        for ((key, values) in extra) {
+            merge(key, values) { existing, new -> existing + new }
+        }
+    }
+}

--- a/library/src/main/kotlin/io/github/ichizero/connect/ktor/streaming/StreamingTrailers.kt
+++ b/library/src/main/kotlin/io/github/ichizero/connect/ktor/streaming/StreamingTrailers.kt
@@ -11,11 +11,6 @@ private val ConnectResponseTrailersKey: AttributeKey<HeadersBuilder> =
 /**
  * Trailers to send in the end-stream frame of a Connect streaming response.
  *
- * Streaming RPCs carry their trailers inside the terminating envelope frame (`metadata`), not as
- * HTTP headers, so they cannot be set through [io.ktor.server.response.ApplicationResponse.headers].
- * A server-streaming handler returns a `Flow`, which has no slot for them either — hence this
- * call-scoped builder.
- *
  * Values are read once, when the end-stream frame is written, so a handler may append to it either
  * before returning the flow or while the flow is being collected. Keys are lowercased on the wire
  * per the Connect protocol.

--- a/library/src/main/kotlin/io/github/ichizero/ktor/protovalidate/ProtoRequestValidation.kt
+++ b/library/src/main/kotlin/io/github/ichizero/ktor/protovalidate/ProtoRequestValidation.kt
@@ -39,12 +39,7 @@ val ProtoRequestValidation: RouteScopedPlugin<ProtoRequestValidationConfig> = cr
     }
 
     on(RequestBodyTransformed) { content ->
-        if (content !is Message) return@on
-
-        val result = validator.validate(content)
-        if (result.isSuccess) return@on
-
-        throw ProtoRequestValidationException(content, result)
+        validator.validationFailure(content)?.let { throw it }
     }
 }
 
@@ -80,10 +75,12 @@ private val StreamingRequestValidatorKey = AttributeKey<Validator>("ConnectStrea
 
 /** Validate an already decoded streaming message using the validator installed on this call's route. */
 internal fun ApplicationCall.validateStreamingRequest(content: Any) {
-    if (content !is Message) return
     val validator = attributes.getOrNull(StreamingRequestValidatorKey) ?: return
-    val result = validator.validate(content)
-    if (!result.isSuccess) {
-        throw ProtoRequestValidationException(content, result).toConnectException()
-    }
+    validator.validationFailure(content)?.let { throw it.toConnectException() }
+}
+
+private fun Validator.validationFailure(content: Any): ProtoRequestValidationException? {
+    if (content !is Message) return null
+    val result = validate(content)
+    return if (result.isSuccess) null else ProtoRequestValidationException(content, result)
 }

--- a/library/src/main/kotlin/io/github/ichizero/ktor/protovalidate/ProtoRequestValidation.kt
+++ b/library/src/main/kotlin/io/github/ichizero/ktor/protovalidate/ProtoRequestValidation.kt
@@ -12,12 +12,15 @@ import io.github.ichizero.connect.ktor.toConnectErrorDetails
 import io.github.ichizero.connect.ktor.toErrorJsonBytes
 import io.ktor.server.application.*
 import io.ktor.server.request.*
+import io.ktor.util.AttributeKey
 
 /**
  * A plugin that checks a request body using [Validator].
  *
  * If validation fails, it will throw [ProtoRequestValidationException].
  * If there are any validation exceptions, it will throw [ValidationException].
+ * Server-streaming requests use the same validator after decoding; violations are returned as
+ * INVALID_ARGUMENT end-stream errors with the validation details.
  */
 val ProtoRequestValidation: RouteScopedPlugin<ProtoRequestValidationConfig> = createRouteScopedPlugin(
     "ProtoRequestValidation",
@@ -29,6 +32,10 @@ val ProtoRequestValidation: RouteScopedPlugin<ProtoRequestValidationConfig> = cr
         ValidatorFactory.newBuilder().withConfig(pluginConfig.config).build()
     } else {
         ValidatorFactory.newBuilder().build()
+    }
+
+    onCall { call ->
+        call.attributes.put(StreamingRequestValidatorKey, validator)
     }
 
     on(RequestBodyTransformed) { content ->
@@ -52,11 +59,13 @@ class ProtoRequestValidationException internal constructor(
         private val errorDetailParser = GoogleJavaJSONStrategy().errorDetailParser()
     }
 
-    fun toErrorJsonBytes(message: String = "invalid request"): ByteArray = ConnectException(
+    fun toErrorJsonBytes(message: String = "invalid request"): ByteArray =
+        toConnectException(message).toErrorJsonBytes()
+
+    internal fun toConnectException(message: String = "invalid request"): ConnectException = ConnectException(
         code = Code.INVALID_ARGUMENT,
         message = message,
     ).withErrorDetails(errorDetailParser, result.violations.map { it.toProto() }.toConnectErrorDetails())
-        .toErrorJsonBytes()
 }
 
 private object RequestBodyTransformed : Hook<suspend (content: Any) -> Unit> {
@@ -64,5 +73,17 @@ private object RequestBodyTransformed : Hook<suspend (content: Any) -> Unit> {
         pipeline.receivePipeline.intercept(ApplicationReceivePipeline.After) {
             handler(subject)
         }
+    }
+}
+
+private val StreamingRequestValidatorKey = AttributeKey<Validator>("ConnectStreamingRequestValidator")
+
+/** Validate an already decoded streaming message using the validator installed on this call's route. */
+internal fun ApplicationCall.validateStreamingRequest(content: Any) {
+    if (content !is Message) return
+    val validator = attributes.getOrNull(StreamingRequestValidatorKey) ?: return
+    val result = validator.validate(content)
+    if (!result.isSuccess) {
+        throw ProtoRequestValidationException(content, result).toConnectException()
     }
 }

--- a/library/src/test/kotlin/io/github/ichizero/connect/ktor/HandleGetTest.kt
+++ b/library/src/test/kotlin/io/github/ichizero/connect/ktor/HandleGetTest.kt
@@ -2,6 +2,8 @@ package io.github.ichizero.connect.ktor
 
 import com.connectrpc.ResponseMessage
 import com.connectrpc.eliza.v1.ElizaServiceHandlerInterface
+import com.connectrpc.eliza.v1.IntroduceRequest
+import com.connectrpc.eliza.v1.IntroduceResponse
 import com.connectrpc.eliza.v1.SayRequest
 import com.connectrpc.eliza.v1.SayResponse
 import com.connectrpc.eliza.v1.elizaService
@@ -25,6 +27,8 @@ import io.ktor.server.application.install
 import io.ktor.server.resources.Resources
 import io.ktor.server.routing.routing
 import io.ktor.server.testing.testApplication
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
 import java.util.Base64
 import kotlin.reflect.KClass
 
@@ -38,6 +42,12 @@ private object EchoHandler : ElizaServiceHandlerInterface {
         emptyMap(),
         emptyMap(),
     )
+
+    // Connect GET only covers unary RPCs; the server-streaming member is unused here.
+    override suspend fun introduce(
+        request: IntroduceRequest,
+        call: ApplicationCall,
+    ): Flow<IntroduceResponse> = emptyFlow()
 }
 
 class HandleGetTest : FunSpec({
@@ -261,6 +271,11 @@ class HandleGetTest : FunSpec({
                 if (params != null) capturedQueryParams += params
                 return ResponseMessage.Success(sayResponse { sentence = "" }, emptyMap(), emptyMap())
             }
+
+            override suspend fun introduce(
+                request: IntroduceRequest,
+                call: ApplicationCall,
+            ): Flow<IntroduceResponse> = emptyFlow()
         }
 
         testApplication {

--- a/library/src/test/kotlin/io/github/ichizero/connect/ktor/streaming/EnvelopeTestSupport.kt
+++ b/library/src/test/kotlin/io/github/ichizero/connect/ktor/streaming/EnvelopeTestSupport.kt
@@ -1,0 +1,38 @@
+package io.github.ichizero.connect.ktor.streaming
+
+import java.io.ByteArrayOutputStream
+
+// Independent wire helpers: do not use the production reader/writer to build test expectations.
+internal fun encodeTestFrame(payload: ByteArray, flags: Byte = 0): ByteArray = byteArrayOf(
+    flags,
+    ((payload.size ushr 24) and 0xFF).toByte(),
+    ((payload.size ushr 16) and 0xFF).toByte(),
+    ((payload.size ushr 8) and 0xFF).toByte(),
+    (payload.size and 0xFF).toByte(),
+) + payload
+
+internal fun decodeTestFrames(bytes: ByteArray): List<EnvelopeFrame> {
+    val frames = mutableListOf<EnvelopeFrame>()
+    var i = 0
+    while (i < bytes.size) {
+        if (i + ENVELOPE_HEADER_SIZE > bytes.size) error("truncated header at $i")
+        val flags = bytes[i]
+        val length = ((bytes[i + 1].toInt() and 0xFF) shl 24) or
+            ((bytes[i + 2].toInt() and 0xFF) shl 16) or
+            ((bytes[i + 3].toInt() and 0xFF) shl 8) or
+            (bytes[i + 4].toInt() and 0xFF)
+        if (i + ENVELOPE_HEADER_SIZE + length > bytes.size) {
+            error("truncated payload at $i: declared length $length exceeds remaining bytes")
+        }
+        val payload = bytes.copyOfRange(i + ENVELOPE_HEADER_SIZE, i + ENVELOPE_HEADER_SIZE + length)
+        frames.add(EnvelopeFrame(flags, payload))
+        i += ENVELOPE_HEADER_SIZE + length
+    }
+    return frames
+}
+
+internal fun encodeTestFrames(payloads: List<ByteArray>, endStream: Boolean = true): ByteArray =
+    ByteArrayOutputStream().apply {
+        payloads.forEach { write(encodeTestFrame(it)) }
+        if (endStream) write(encodeTestFrame("{}".toByteArray(Charsets.UTF_8), flags = 2))
+    }.toByteArray()

--- a/library/src/test/kotlin/io/github/ichizero/connect/ktor/streaming/HandleClientStreamTest.kt
+++ b/library/src/test/kotlin/io/github/ichizero/connect/ktor/streaming/HandleClientStreamTest.kt
@@ -56,7 +56,7 @@ class HandleClientStreamTest : FunSpec({
         response.status shouldBe HttpStatusCode.OK
         response.parseContentType()?.contentSubtype shouldBe "connect+proto"
 
-        val frames = decodeFrames(response.bodyAsBytes())
+        val frames = decodeTestFrames(response.bodyAsBytes())
         frames.size shouldBe 2
         frames[0].isEndStream shouldBe false
         frames[1].isEndStream shouldBe true
@@ -82,7 +82,7 @@ class HandleClientStreamTest : FunSpec({
         }
 
         response.status shouldBe HttpStatusCode.OK
-        val frames = decodeFrames(response.bodyAsBytes())
+        val frames = decodeTestFrames(response.bodyAsBytes())
         frames.size shouldBe 1
         frames[0].isEndStream shouldBe true
         val json = String(frames[0].payload)
@@ -98,7 +98,7 @@ class HandleClientStreamTest : FunSpec({
         }
 
         response.status shouldBe HttpStatusCode.OK
-        val frames = decodeFrames(response.bodyAsBytes())
+        val frames = decodeTestFrames(response.bodyAsBytes())
         frames.size shouldBe 1
         frames[0].isEndStream shouldBe true
         val json = String(frames[0].payload)
@@ -113,7 +113,7 @@ class HandleClientStreamTest : FunSpec({
             throw ConnectException(code = Code.PERMISSION_DENIED, message = "no")
         }
 
-        val frames = decodeFrames(response.bodyAsBytes())
+        val frames = decodeTestFrames(response.bodyAsBytes())
         frames.size shouldBe 1
         String(frames[0].payload) shouldBe """{"error":{"code":"permission_denied","message":"no"}}"""
     }
@@ -132,7 +132,7 @@ class HandleClientStreamTest : FunSpec({
             )
         }
 
-        val frames = decodeFrames(response.bodyAsBytes())
+        val frames = decodeTestFrames(response.bodyAsBytes())
         frames.size shouldBe 1
         String(frames[0].payload) shouldBe
             """{"error":{"code":"resource_exhausted","message":"slow down"},""" +
@@ -147,7 +147,7 @@ class HandleClientStreamTest : FunSpec({
             ResponseMessage.Success(uploadResponse {}, emptyMap(), emptyMap())
         }
 
-        val frames = decodeFrames(response.bodyAsBytes())
+        val frames = decodeTestFrames(response.bodyAsBytes())
         frames.size shouldBe 1
         frames[0].isEndStream shouldBe true
         val json = String(frames[0].payload)
@@ -167,7 +167,7 @@ class HandleClientStreamTest : FunSpec({
             ResponseMessage.Success(uploadResponse {}, emptyMap(), emptyMap())
         }
 
-        val frames = decodeFrames(response.bodyAsBytes())
+        val frames = decodeTestFrames(response.bodyAsBytes())
         frames.size shouldBe 1
         String(frames[0].payload).contains(""""code":"resource_exhausted"""") shouldBe true
     }
@@ -192,7 +192,7 @@ class HandleClientStreamTest : FunSpec({
         response.status shouldBe HttpStatusCode.OK
         response.parseContentType()?.contentSubtype shouldBe "connect+json"
 
-        val frames = decodeFrames(response.bodyAsBytes())
+        val frames = decodeTestFrames(response.bodyAsBytes())
         frames.size shouldBe 2
         frames[0].isEndStream shouldBe false
         // Data frame is JSON when codec is JSON. Parse it back and assert structurally rather than
@@ -221,7 +221,7 @@ class HandleClientStreamTest : FunSpec({
             )
         }
 
-        val frames = decodeFrames(response.bodyAsBytes())
+        val frames = decodeTestFrames(response.bodyAsBytes())
         frames.size shouldBe 2
         frames[1].isEndStream shouldBe true
         String(frames[1].payload) shouldBe """{"metadata":{"x-checksum":["deadbeef"]}}"""
@@ -238,7 +238,7 @@ class HandleClientStreamTest : FunSpec({
             ResponseMessage.Success(uploadResponse {}, emptyMap(), emptyMap())
         }
 
-        val frames = decodeFrames(response.bodyAsBytes())
+        val frames = decodeTestFrames(response.bodyAsBytes())
         frames.size shouldBe 1
         frames[0].isEndStream shouldBe true
         String(frames[0].payload).contains(""""code":"deadline_exceeded"""") shouldBe true
@@ -256,7 +256,7 @@ class HandleClientStreamTest : FunSpec({
             ResponseMessage.Success(uploadResponse {}, emptyMap(), emptyMap())
         }
 
-        val frames = decodeFrames(response.bodyAsBytes())
+        val frames = decodeTestFrames(response.bodyAsBytes())
         frames.size shouldBe 1
         frames[0].isEndStream shouldBe true
         String(frames[0].payload).contains(""""code":"invalid_argument"""") shouldBe true
@@ -313,69 +313,11 @@ private fun Application.configureUpload(
 
 private fun encodeJsonFrames(reqs: List<UploadRequest>): ByteArray {
     val printer = com.google.protobuf.util.JsonFormat.printer().omittingInsignificantWhitespace()
-    val out = mutableListOf<Byte>()
-    for (r in reqs) {
-        val bytes = printer.print(r).toByteArray(Charsets.UTF_8)
-        out.add(0)
-        out.add(((bytes.size ushr 24) and 0xFF).toByte())
-        out.add(((bytes.size ushr 16) and 0xFF).toByte())
-        out.add(((bytes.size ushr 8) and 0xFF).toByte())
-        out.add((bytes.size and 0xFF).toByte())
-        out.addAll(bytes.toList())
-    }
-    // Send end-stream frame with empty JSON.
-    out.add(0x02)
-    out.add(0)
-    out.add(0)
-    out.add(0)
-    out.add(2)
-    out.add('{'.code.toByte())
-    out.add('}'.code.toByte())
-    return out.toByteArray()
+    return encodeTestFrames(reqs.map { printer.print(it).toByteArray(Charsets.UTF_8) })
 }
 
-private fun encodeFrames(reqs: List<UploadRequest>, endStream: Boolean = true): ByteArray {
-    val out = mutableListOf<Byte>()
-    for (r in reqs) {
-        val bytes = r.toByteArray()
-        out.add(0)
-        out.add(((bytes.size ushr 24) and 0xFF).toByte())
-        out.add(((bytes.size ushr 16) and 0xFF).toByte())
-        out.add(((bytes.size ushr 8) and 0xFF).toByte())
-        out.add((bytes.size and 0xFF).toByte())
-        out.addAll(bytes.toList())
-    }
-    if (endStream) {
-        out.add(0x02) // end-stream flag
-        out.add(0)
-        out.add(0)
-        out.add(0)
-        out.add(2)
-        out.add('{'.code.toByte())
-        out.add('}'.code.toByte())
-    }
-    return out.toByteArray()
-}
-
-private fun decodeFrames(bytes: ByteArray): List<EnvelopeFrame> {
-    val frames = mutableListOf<EnvelopeFrame>()
-    var i = 0
-    while (i < bytes.size) {
-        if (i + ENVELOPE_HEADER_SIZE > bytes.size) error("truncated header at $i")
-        val flags = bytes[i]
-        val length = ((bytes[i + 1].toInt() and 0xFF) shl 24) or
-            ((bytes[i + 2].toInt() and 0xFF) shl 16) or
-            ((bytes[i + 3].toInt() and 0xFF) shl 8) or
-            (bytes[i + 4].toInt() and 0xFF)
-        if (i + ENVELOPE_HEADER_SIZE + length > bytes.size) {
-            error("truncated payload at $i: declared length $length exceeds remaining bytes")
-        }
-        val payload = bytes.copyOfRange(i + ENVELOPE_HEADER_SIZE, i + ENVELOPE_HEADER_SIZE + length)
-        frames.add(EnvelopeFrame(flags, payload))
-        i += ENVELOPE_HEADER_SIZE + length
-    }
-    return frames
-}
+private fun encodeFrames(reqs: List<UploadRequest>, endStream: Boolean = true): ByteArray =
+    encodeTestFrames(reqs.map { it.toByteArray() }, endStream)
 
 private fun HttpResponse.parseContentType(): ContentType? =
     headers[HttpHeaders.ContentType]?.let { ContentType.parse(it) }

--- a/library/src/test/kotlin/io/github/ichizero/connect/ktor/streaming/HandleServerStreamCancellationTest.kt
+++ b/library/src/test/kotlin/io/github/ichizero/connect/ktor/streaming/HandleServerStreamCancellationTest.kt
@@ -1,0 +1,114 @@
+package io.github.ichizero.connect.ktor.streaming
+
+import com.stricteliza.v1.CountdownRequest
+import com.stricteliza.v1.CountdownResponse
+import com.stricteliza.v1.countdownRequest
+import com.stricteliza.v1.countdownResponse
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.ktor.resources.Resource
+import io.ktor.server.application.install
+import io.ktor.server.cio.CIO
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.resources.Resources
+import io.ktor.server.resources.post
+import io.ktor.server.routing.routing
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import java.net.Socket
+
+/**
+ * Cancellation propagation needs a real engine and a real socket: the in-memory test host never
+ * breaks a connection the way a client that walks away does.
+ */
+class HandleServerStreamCancellationTest : FunSpec({
+    test("server streaming: a client disconnect cancels the handler's flow") {
+        val collectorReleased = CompletableDeferred<Unit>()
+
+        val server = embeddedServer(CIO, port = 0) {
+            install(Resources)
+            routing {
+                post<CancellingCountdownResource>(
+                    handleServerStream<CancellingCountdownResource, CountdownRequest, CountdownResponse>(
+                        handlerFunc = { _, _ ->
+                            flow {
+                                try {
+                                    // Bounded so a server that never notices the disconnect fails the
+                                    // test on the await() timeout instead of streaming forever.
+                                    repeat(MAX_MESSAGES) { value ->
+                                        emit(countdownResponse { this.value = value })
+                                        delay(EMIT_INTERVAL_MS)
+                                    }
+                                } finally {
+                                    // Stands in for whatever resource a real producer would hold.
+                                    collectorReleased.complete(Unit)
+                                }
+                            }
+                        },
+                    ),
+                )
+            }
+        }
+        server.start(wait = false)
+
+        try {
+            val port = server.engine.resolvedConnectors().first().port
+
+            withContext(Dispatchers.IO) {
+                Socket("127.0.0.1", port).use { socket ->
+                    socket.soTimeout = SOCKET_TIMEOUT_MS
+                    socket.tcpNoDelay = true
+                    socket.sendRequest(port, countdownRequest { from = 1 })
+
+                    // Block until the server has begun responding, so the disconnect lands mid-stream.
+                    val firstByte = socket.getInputStream().read()
+                    firstByte shouldBe 'H'.code
+
+                    // Close with a RST rather than a FIN so the server's next write fails promptly.
+                    socket.setSoLinger(true, 0)
+                }
+            }
+
+            withTimeout(RELEASE_TIMEOUT_MS) { collectorReleased.await() }
+        } finally {
+            server.stop()
+        }
+    }
+})
+
+private const val MAX_MESSAGES = 10_000
+private const val EMIT_INTERVAL_MS = 20L
+private const val SOCKET_TIMEOUT_MS = 10_000
+private const val RELEASE_TIMEOUT_MS = 10_000L
+
+@Resource("/stricteliza.v1.StrictElizaService/Countdown")
+private class CancellingCountdownResource
+
+private fun Socket.sendRequest(port: Int, request: CountdownRequest) {
+    val payload = request.toByteArray()
+    val body = byteArrayOf(
+        0,
+        ((payload.size ushr 24) and 0xFF).toByte(),
+        ((payload.size ushr 16) and 0xFF).toByte(),
+        ((payload.size ushr 8) and 0xFF).toByte(),
+        (payload.size and 0xFF).toByte(),
+    ) + payload
+
+    val head = (
+        "POST /stricteliza.v1.StrictElizaService/Countdown HTTP/1.1\r\n" +
+            "Host: 127.0.0.1:$port\r\n" +
+            "Content-Type: application/connect+proto\r\n" +
+            "Content-Length: ${body.size}\r\n" +
+            "\r\n"
+        ).toByteArray(Charsets.US_ASCII)
+
+    getOutputStream().apply {
+        write(head)
+        write(body)
+        flush()
+    }
+}

--- a/library/src/test/kotlin/io/github/ichizero/connect/ktor/streaming/HandleServerStreamCancellationTest.kt
+++ b/library/src/test/kotlin/io/github/ichizero/connect/ktor/streaming/HandleServerStreamCancellationTest.kt
@@ -28,6 +28,7 @@ import java.net.Socket
 class HandleServerStreamCancellationTest : FunSpec({
     test("server streaming: a client disconnect cancels the handler's flow") {
         val collectorReleased = CompletableDeferred<Unit>()
+        val collectorStarted = CompletableDeferred<Unit>()
 
         val server = embeddedServer(CIO, port = 0) {
             install(Resources)
@@ -37,6 +38,7 @@ class HandleServerStreamCancellationTest : FunSpec({
                         handlerFunc = { _, _ ->
                             flow {
                                 try {
+                                    collectorStarted.complete(Unit)
                                     // Bounded so a server that never notices the disconnect fails the
                                     // test on the await() timeout instead of streaming forever.
                                     repeat(MAX_MESSAGES) { value ->
@@ -67,6 +69,7 @@ class HandleServerStreamCancellationTest : FunSpec({
                     // Block until the server has begun responding, so the disconnect lands mid-stream.
                     val firstByte = socket.getInputStream().read()
                     firstByte shouldBe 'H'.code
+                    withTimeout(RELEASE_TIMEOUT_MS) { collectorStarted.await() }
 
                     // Close with a RST rather than a FIN so the server's next write fails promptly.
                     socket.setSoLinger(true, 0)

--- a/library/src/test/kotlin/io/github/ichizero/connect/ktor/streaming/HandleServerStreamTest.kt
+++ b/library/src/test/kotlin/io/github/ichizero/connect/ktor/streaming/HandleServerStreamTest.kt
@@ -1,0 +1,360 @@
+package io.github.ichizero.connect.ktor.streaming
+
+import com.connectrpc.Code
+import com.connectrpc.ConnectException
+import com.stricteliza.v1.CountdownRequest
+import com.stricteliza.v1.CountdownResponse
+import com.stricteliza.v1.countdownRequest
+import com.stricteliza.v1.countdownResponse
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsBytes
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.resources.Resource
+import io.ktor.server.application.Application
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.application.install
+import io.ktor.server.resources.Resources
+import io.ktor.server.resources.post
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.testApplication
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flow
+
+class HandleServerStreamTest : FunSpec({
+    test("server streaming: 3 messages produce 3 data frames plus an end frame") {
+        val response = postCountdown(
+            contentType = ConnectStreamingContentType.Proto,
+            body = encodeFrame(countdownRequest { from = 3 }),
+        ) { request, _ ->
+            flow {
+                for (value in request.from downTo 1) {
+                    emit(countdownResponse { this.value = value })
+                }
+            }
+        }
+
+        response.status shouldBe HttpStatusCode.OK
+        response.parseContentType()?.contentSubtype shouldBe "connect+proto"
+
+        val frames = decodeFrames(response.bodyAsBytes())
+        frames.size shouldBe 4
+        frames.dropLast(1).map { it.isEndStream } shouldBe listOf(false, false, false)
+        frames.dropLast(1).map { CountdownResponse.parseFrom(it.payload).value } shouldBe listOf(3, 2, 1)
+
+        frames.last().isEndStream shouldBe true
+        String(frames.last().payload) shouldBe "{}"
+    }
+
+    test("server streaming: empty flow produces an end frame only") {
+        val response = postCountdown(
+            contentType = ConnectStreamingContentType.Proto,
+            body = encodeFrame(countdownRequest { from = 0 }),
+        ) { _, _ -> emptyFlow() }
+
+        response.status shouldBe HttpStatusCode.OK
+        val frames = decodeFrames(response.bodyAsBytes())
+        frames.size shouldBe 1
+        frames[0].isEndStream shouldBe true
+        String(frames[0].payload) shouldBe "{}"
+    }
+
+    test("server streaming: response headers are HTTP headers, trailers ride the end frame") {
+        val response = postCountdown(
+            contentType = ConnectStreamingContentType.Proto,
+            body = encodeFrame(countdownRequest { from = 1 }),
+        ) { _, call ->
+            call.response.headers.append("x-custom-header", "foo")
+            call.connectResponseTrailers().append("x-custom-trailer", "bing")
+            flow { emit(countdownResponse { value = 1 }) }
+        }
+
+        response.headers["x-custom-header"] shouldBe "foo"
+        response.headers["x-custom-trailer"] shouldBe null
+
+        val frames = decodeFrames(response.bodyAsBytes())
+        frames.size shouldBe 2
+        String(frames[1].payload) shouldBe """{"metadata":{"x-custom-trailer":["bing"]}}"""
+    }
+
+    test("server streaming: trailers keep every value of a repeated key") {
+        val response = postCountdown(
+            contentType = ConnectStreamingContentType.Proto,
+            body = encodeFrame(countdownRequest { from = 0 }),
+        ) { _, call ->
+            call.connectResponseTrailers().appendAll("x-custom-trailer", listOf("bing", "quux"))
+            emptyFlow()
+        }
+
+        val frames = decodeFrames(response.bodyAsBytes())
+        String(frames[0].payload) shouldBe """{"metadata":{"x-custom-trailer":["bing","quux"]}}"""
+    }
+
+    test("server streaming: failure after some messages keeps the emitted data frames") {
+        val response = postCountdown(
+            contentType = ConnectStreamingContentType.Proto,
+            body = encodeFrame(countdownRequest { from = 2 }),
+        ) { _, call ->
+            call.connectResponseTrailers().append("x-custom-trailer", "bing")
+            flow {
+                emit(countdownResponse { value = 2 })
+                emit(countdownResponse { value = 1 })
+                throw ConnectException(code = Code.INTERNAL_ERROR, message = "server stream failed")
+            }
+        }
+
+        response.status shouldBe HttpStatusCode.OK
+        val frames = decodeFrames(response.bodyAsBytes())
+        frames.size shouldBe 3
+        frames.dropLast(1).map { CountdownResponse.parseFrom(it.payload).value } shouldBe listOf(2, 1)
+        String(frames.last().payload) shouldBe
+            """{"error":{"code":"internal","message":"server stream failed"},""" +
+            """"metadata":{"x-custom-trailer":["bing"]}}"""
+    }
+
+    test("server streaming: non-Connect exception is mapped to UNKNOWN") {
+        val response = postCountdown(
+            contentType = ConnectStreamingContentType.Proto,
+            body = encodeFrame(countdownRequest { from = 1 }),
+        ) { _, _ ->
+            flow<CountdownResponse> { throw IllegalStateException("boom") }
+        }
+
+        val frames = decodeFrames(response.bodyAsBytes())
+        frames.size shouldBe 1
+        String(frames[0].payload) shouldBe """{"error":{"code":"unknown","message":"boom"}}"""
+    }
+
+    test("server streaming: ConnectException.metadata is merged into end-stream trailers") {
+        val response = postCountdown(
+            contentType = ConnectStreamingContentType.Proto,
+            body = encodeFrame(countdownRequest { from = 1 }),
+        ) { _, call ->
+            call.connectResponseTrailers().append("x-custom-trailer", "bing")
+            flow<CountdownResponse> {
+                throw ConnectException(
+                    code = Code.RESOURCE_EXHAUSTED,
+                    message = "slow down",
+                    metadata = mapOf("retry-after" to listOf("30")),
+                )
+            }
+        }
+
+        val frames = decodeFrames(response.bodyAsBytes())
+        String(frames[0].payload) shouldBe
+            """{"error":{"code":"resource_exhausted","message":"slow down"},""" +
+            """"metadata":{"x-custom-trailer":["bing"],"retry-after":["30"]}}"""
+    }
+
+    test("server streaming: exception thrown before the flow is returned yields an end-frame-only body") {
+        val response = postCountdown(
+            contentType = ConnectStreamingContentType.Proto,
+            body = encodeFrame(countdownRequest { from = 1 }),
+        ) { _, _ ->
+            throw ConnectException(code = Code.PERMISSION_DENIED, message = "no")
+        }
+
+        val frames = decodeFrames(response.bodyAsBytes())
+        frames.size shouldBe 1
+        String(frames[0].payload) shouldBe """{"error":{"code":"permission_denied","message":"no"}}"""
+    }
+
+    test("server streaming: JSON content-type round-trips data and end frames") {
+        val response = postCountdown(
+            contentType = ConnectStreamingContentType.Json,
+            body = encodeJsonFrame(countdownRequest { from = 2 }),
+        ) { request, _ ->
+            flow {
+                for (value in request.from downTo 1) {
+                    emit(countdownResponse { this.value = value })
+                }
+            }
+        }
+
+        response.parseContentType()?.contentSubtype shouldBe "connect+json"
+        val frames = decodeFrames(response.bodyAsBytes())
+        frames.size shouldBe 3
+        val decoded = CountdownResponse.newBuilder().also {
+            com.google.protobuf.util.JsonFormat.parser().merge(String(frames[0].payload), it)
+        }.build()
+        decoded.value shouldBe 2
+        String(frames.last().payload) shouldBe "{}"
+    }
+
+    test("server streaming: a request without any message is rejected with UNIMPLEMENTED") {
+        val response = postCountdown(
+            contentType = ConnectStreamingContentType.Proto,
+            body = byteArrayOf(),
+        ) { _, _ -> emptyFlow() }
+
+        val frames = decodeFrames(response.bodyAsBytes())
+        frames.size shouldBe 1
+        String(frames[0].payload) shouldBe
+            """{"error":{"code":"unimplemented","message":"unary request has zero messages"}}"""
+    }
+
+    test("server streaming: a request with multiple messages is rejected with UNIMPLEMENTED") {
+        val response = postCountdown(
+            contentType = ConnectStreamingContentType.Proto,
+            body = encodeFrame(countdownRequest { from = 1 }) + encodeFrame(countdownRequest { from = 2 }),
+        ) { _, _ -> emptyFlow() }
+
+        val frames = decodeFrames(response.bodyAsBytes())
+        frames.size shouldBe 1
+        String(frames[0].payload) shouldBe
+            """{"error":{"code":"unimplemented","message":"unary request has multiple messages"}}"""
+    }
+
+    test("server streaming: a compressed request frame is a protocol error") {
+        val payload = countdownRequest { from = 1 }.toByteArray()
+        val compressedFrame = byteArrayOf(1, 0, 0, 0, payload.size.toByte()) + payload
+        val response = postCountdown(
+            contentType = ConnectStreamingContentType.Proto,
+            body = compressedFrame,
+        ) { _, _ -> emptyFlow() }
+
+        val frames = decodeFrames(response.bodyAsBytes())
+        frames.size shouldBe 1
+        String(frames[0].payload) shouldBe """{"error":{"code":"internal",""" +
+            """"message":"protocol error: sent compressed message without connect-content-encoding"}}"""
+    }
+
+    test("server streaming: malformed request frame yields INVALID_ARGUMENT") {
+        val garbage = byteArrayOf(0xFF.toByte(), 0xFE.toByte(), 0xFD.toByte())
+        val response = postCountdown(
+            contentType = ConnectStreamingContentType.Proto,
+            body = byteArrayOf(0x00, 0x00, 0x00, 0x00, garbage.size.toByte()) + garbage,
+        ) { _, _ -> emptyFlow() }
+
+        val frames = decodeFrames(response.bodyAsBytes())
+        frames.size shouldBe 1
+        String(frames[0].payload).contains(""""code":"invalid_argument"""") shouldBe true
+    }
+
+    test("server streaming: messages larger than maxMessageSize fail with RESOURCE_EXHAUSTED") {
+        val big = ByteArray(1024) { 'a'.code.toByte() }
+        val response = postCountdown(
+            contentType = ConnectStreamingContentType.Proto,
+            body = byteArrayOf(0x00, 0x00, 0x00, 0x00, big.size.toByte()) + big,
+            maxMessageSize = 64,
+        ) { _, _ -> emptyFlow() }
+
+        val frames = decodeFrames(response.bodyAsBytes())
+        frames.size shouldBe 1
+        String(frames[0].payload).contains(""""code":"resource_exhausted"""") shouldBe true
+    }
+
+    test("server streaming: unsupported content-type produces end frame with UNIMPLEMENTED") {
+        val response = postCountdown(
+            contentType = ContentType("application", "json"),
+            body = byteArrayOf(),
+        ) { _, _ -> emptyFlow() }
+
+        response.parseContentType()?.contentSubtype shouldBe "connect+json"
+        val frames = decodeFrames(response.bodyAsBytes())
+        frames.size shouldBe 1
+        String(frames[0].payload).contains(""""code":"unimplemented"""") shouldBe true
+    }
+
+    test("server streaming: Connect-Timeout-Ms expiry produces DEADLINE_EXCEEDED") {
+        val response = postCountdown(
+            contentType = ConnectStreamingContentType.Proto,
+            body = encodeFrame(countdownRequest { from = 1 }),
+            extraHeaders = mapOf("connect-timeout-ms" to "50"),
+        ) { _, _ ->
+            flow {
+                emit(countdownResponse { value = 1 })
+                // Block past the deadline before the stream would complete.
+                kotlinx.coroutines.delay(500)
+                emit(countdownResponse { value = 0 })
+            }
+        }
+
+        val frames = decodeFrames(response.bodyAsBytes())
+        frames.size shouldBe 2
+        frames[0].isEndStream shouldBe false
+        String(frames[1].payload).contains(""""code":"deadline_exceeded"""") shouldBe true
+    }
+})
+
+@Resource("/stricteliza.v1.StrictElizaService/Countdown")
+private class CountdownResource
+
+private suspend fun postCountdown(
+    contentType: ContentType,
+    body: ByteArray,
+    maxMessageSize: Int = DEFAULT_MAX_MESSAGE_SIZE,
+    extraHeaders: Map<String, String> = emptyMap(),
+    handler: suspend (CountdownRequest, ApplicationCall) -> Flow<CountdownResponse>,
+): HttpResponse {
+    lateinit var resp: HttpResponse
+    testApplication {
+        application { configureCountdown(maxMessageSize, handler) }
+        resp = client.post("/stricteliza.v1.StrictElizaService/Countdown") {
+            header(HttpHeaders.ContentType, contentType.toString())
+            extraHeaders.forEach { (k, v) -> header(k, v) }
+            setBody(body)
+        }
+    }
+    return resp
+}
+
+private fun Application.configureCountdown(
+    maxMessageSize: Int,
+    handler: suspend (CountdownRequest, ApplicationCall) -> Flow<CountdownResponse>,
+) {
+    install(Resources)
+    routing {
+        post<CountdownResource>(
+            handleServerStream<CountdownResource, CountdownRequest, CountdownResponse>(
+                handlerFunc = handler,
+                maxMessageSize = maxMessageSize,
+            ),
+        )
+    }
+}
+
+private fun encodeFrame(request: CountdownRequest): ByteArray = frame(request.toByteArray())
+
+private fun encodeJsonFrame(request: CountdownRequest): ByteArray {
+    val printer = com.google.protobuf.util.JsonFormat.printer().omittingInsignificantWhitespace()
+    return frame(printer.print(request).toByteArray(Charsets.UTF_8))
+}
+
+private fun frame(payload: ByteArray): ByteArray = byteArrayOf(
+    0,
+    ((payload.size ushr 24) and 0xFF).toByte(),
+    ((payload.size ushr 16) and 0xFF).toByte(),
+    ((payload.size ushr 8) and 0xFF).toByte(),
+    (payload.size and 0xFF).toByte(),
+) + payload
+
+private fun decodeFrames(bytes: ByteArray): List<EnvelopeFrame> {
+    val frames = mutableListOf<EnvelopeFrame>()
+    var i = 0
+    while (i < bytes.size) {
+        if (i + ENVELOPE_HEADER_SIZE > bytes.size) error("truncated header at $i")
+        val flags = bytes[i]
+        val length = ((bytes[i + 1].toInt() and 0xFF) shl 24) or
+            ((bytes[i + 2].toInt() and 0xFF) shl 16) or
+            ((bytes[i + 3].toInt() and 0xFF) shl 8) or
+            (bytes[i + 4].toInt() and 0xFF)
+        if (i + ENVELOPE_HEADER_SIZE + length > bytes.size) {
+            error("truncated payload at $i: declared length $length exceeds remaining bytes")
+        }
+        val payload = bytes.copyOfRange(i + ENVELOPE_HEADER_SIZE, i + ENVELOPE_HEADER_SIZE + length)
+        frames.add(EnvelopeFrame(flags, payload))
+        i += ENVELOPE_HEADER_SIZE + length
+    }
+    return frames
+}
+
+private fun HttpResponse.parseContentType(): ContentType? =
+    headers[HttpHeaders.ContentType]?.let { ContentType.parse(it) }

--- a/library/src/test/kotlin/io/github/ichizero/connect/ktor/streaming/HandleServerStreamTest.kt
+++ b/library/src/test/kotlin/io/github/ichizero/connect/ktor/streaming/HandleServerStreamTest.kt
@@ -68,10 +68,10 @@ class HandleServerStreamTest : FunSpec({
                     }
                     val response = client.post("/$prefix/stricteliza.v1.StrictElizaService/Countdown") {
                         header(HttpHeaders.ContentType, contentType.toString())
-                        setBody(frame(payload))
+                        setBody(encodeTestFrame(payload))
                     }
                     response.status shouldBe HttpStatusCode.OK
-                    val frames = decodeFrames(response.bodyAsBytes())
+                    val frames = decodeTestFrames(response.bodyAsBytes())
                     frames.size shouldBe 1
                     frames.single().isEndStream shouldBe true
                     val end = String(frames.single().payload)
@@ -122,7 +122,7 @@ class HandleServerStreamTest : FunSpec({
         response.status shouldBe HttpStatusCode.OK
         response.parseContentType()?.contentSubtype shouldBe "connect+proto"
 
-        val frames = decodeFrames(response.bodyAsBytes())
+        val frames = decodeTestFrames(response.bodyAsBytes())
         frames.size shouldBe 4
         frames.dropLast(1).map { it.isEndStream } shouldBe listOf(false, false, false)
         frames.dropLast(1).map { CountdownResponse.parseFrom(it.payload).value } shouldBe listOf(3, 2, 1)
@@ -138,7 +138,7 @@ class HandleServerStreamTest : FunSpec({
         ) { _, _ -> emptyFlow() }
 
         response.status shouldBe HttpStatusCode.OK
-        val frames = decodeFrames(response.bodyAsBytes())
+        val frames = decodeTestFrames(response.bodyAsBytes())
         frames.size shouldBe 1
         frames[0].isEndStream shouldBe true
         String(frames[0].payload) shouldBe "{}"
@@ -157,7 +157,7 @@ class HandleServerStreamTest : FunSpec({
         response.headers["x-custom-header"] shouldBe "foo"
         response.headers["x-custom-trailer"] shouldBe null
 
-        val frames = decodeFrames(response.bodyAsBytes())
+        val frames = decodeTestFrames(response.bodyAsBytes())
         frames.size shouldBe 2
         String(frames[1].payload) shouldBe """{"metadata":{"x-custom-trailer":["bing"]}}"""
     }
@@ -171,7 +171,7 @@ class HandleServerStreamTest : FunSpec({
             emptyFlow()
         }
 
-        val frames = decodeFrames(response.bodyAsBytes())
+        val frames = decodeTestFrames(response.bodyAsBytes())
         String(frames[0].payload) shouldBe """{"metadata":{"x-custom-trailer":["bing","quux"]}}"""
     }
 
@@ -189,7 +189,7 @@ class HandleServerStreamTest : FunSpec({
         }
 
         response.status shouldBe HttpStatusCode.OK
-        val frames = decodeFrames(response.bodyAsBytes())
+        val frames = decodeTestFrames(response.bodyAsBytes())
         frames.size shouldBe 3
         frames.dropLast(1).map { CountdownResponse.parseFrom(it.payload).value } shouldBe listOf(2, 1)
         String(frames.last().payload) shouldBe
@@ -205,7 +205,7 @@ class HandleServerStreamTest : FunSpec({
             flow<CountdownResponse> { throw IllegalStateException("boom") }
         }
 
-        val frames = decodeFrames(response.bodyAsBytes())
+        val frames = decodeTestFrames(response.bodyAsBytes())
         frames.size shouldBe 1
         String(frames[0].payload) shouldBe """{"error":{"code":"unknown","message":"boom"}}"""
     }
@@ -221,7 +221,7 @@ class HandleServerStreamTest : FunSpec({
             }
         }
 
-        val frames = decodeFrames(response.bodyAsBytes())
+        val frames = decodeTestFrames(response.bodyAsBytes())
         frames.size shouldBe 2
         CountdownResponse.parseFrom(frames.first().payload).value shouldBe 1
         frames.last().isEndStream shouldBe true
@@ -244,7 +244,7 @@ class HandleServerStreamTest : FunSpec({
             }
         }
 
-        val frames = decodeFrames(response.bodyAsBytes())
+        val frames = decodeTestFrames(response.bodyAsBytes())
         String(frames[0].payload) shouldBe
             """{"error":{"code":"resource_exhausted","message":"slow down"},""" +
             """"metadata":{"x-custom-trailer":["bing"],"retry-after":["30"]}}"""
@@ -258,7 +258,7 @@ class HandleServerStreamTest : FunSpec({
             throw ConnectException(code = Code.PERMISSION_DENIED, message = "no")
         }
 
-        val frames = decodeFrames(response.bodyAsBytes())
+        val frames = decodeTestFrames(response.bodyAsBytes())
         frames.size shouldBe 1
         String(frames[0].payload) shouldBe """{"error":{"code":"permission_denied","message":"no"}}"""
     }
@@ -276,7 +276,7 @@ class HandleServerStreamTest : FunSpec({
         }
 
         response.parseContentType()?.contentSubtype shouldBe "connect+json"
-        val frames = decodeFrames(response.bodyAsBytes())
+        val frames = decodeTestFrames(response.bodyAsBytes())
         frames.size shouldBe 3
         val decoded = CountdownResponse.newBuilder().also {
             com.google.protobuf.util.JsonFormat.parser().merge(String(frames[0].payload), it)
@@ -291,7 +291,7 @@ class HandleServerStreamTest : FunSpec({
             body = byteArrayOf(),
         ) { _, _ -> emptyFlow() }
 
-        val frames = decodeFrames(response.bodyAsBytes())
+        val frames = decodeTestFrames(response.bodyAsBytes())
         frames.size shouldBe 1
         String(frames[0].payload) shouldBe
             """{"error":{"code":"unimplemented","message":"unary request has zero messages"}}"""
@@ -303,7 +303,7 @@ class HandleServerStreamTest : FunSpec({
             body = encodeFrame(countdownRequest { from = 1 }) + encodeFrame(countdownRequest { from = 2 }),
         ) { _, _ -> emptyFlow() }
 
-        val frames = decodeFrames(response.bodyAsBytes())
+        val frames = decodeTestFrames(response.bodyAsBytes())
         frames.size shouldBe 1
         String(frames[0].payload) shouldBe
             """{"error":{"code":"unimplemented","message":"unary request has multiple messages"}}"""
@@ -317,7 +317,7 @@ class HandleServerStreamTest : FunSpec({
             body = compressedFrame,
         ) { _, _ -> emptyFlow() }
 
-        val frames = decodeFrames(response.bodyAsBytes())
+        val frames = decodeTestFrames(response.bodyAsBytes())
         frames.size shouldBe 1
         String(frames[0].payload) shouldBe """{"error":{"code":"internal",""" +
             """"message":"protocol error: sent compressed message without connect-content-encoding"}}"""
@@ -330,7 +330,7 @@ class HandleServerStreamTest : FunSpec({
             body = byteArrayOf(0x00, 0x00, 0x00, 0x00, garbage.size.toByte()) + garbage,
         ) { _, _ -> emptyFlow() }
 
-        val frames = decodeFrames(response.bodyAsBytes())
+        val frames = decodeTestFrames(response.bodyAsBytes())
         frames.size shouldBe 1
         String(frames[0].payload).contains(""""code":"invalid_argument"""") shouldBe true
     }
@@ -339,11 +339,11 @@ class HandleServerStreamTest : FunSpec({
         val big = ByteArray(1024) { 'a'.code.toByte() }
         val response = postCountdown(
             contentType = ConnectStreamingContentType.Proto,
-            body = frame(big),
+            body = encodeTestFrame(big),
             maxMessageSize = 64,
         ) { _, _ -> emptyFlow() }
 
-        val frames = decodeFrames(response.bodyAsBytes())
+        val frames = decodeTestFrames(response.bodyAsBytes())
         frames.size shouldBe 1
         String(frames[0].payload).contains(""""code":"resource_exhausted"""") shouldBe true
     }
@@ -355,7 +355,7 @@ class HandleServerStreamTest : FunSpec({
         ) { _, _ -> emptyFlow() }
 
         response.parseContentType()?.contentSubtype shouldBe "connect+json"
-        val frames = decodeFrames(response.bodyAsBytes())
+        val frames = decodeTestFrames(response.bodyAsBytes())
         frames.size shouldBe 1
         String(frames[0].payload).contains(""""code":"unimplemented"""") shouldBe true
     }
@@ -374,7 +374,7 @@ class HandleServerStreamTest : FunSpec({
             }
         }
 
-        val frames = decodeFrames(response.bodyAsBytes())
+        val frames = decodeTestFrames(response.bodyAsBytes())
         frames.size shouldBe 2
         frames[0].isEndStream shouldBe false
         String(frames[1].payload).contains(""""code":"deadline_exceeded"""") shouldBe true
@@ -418,39 +418,11 @@ private fun Application.configureCountdown(
     }
 }
 
-private fun encodeFrame(request: CountdownRequest): ByteArray = frame(request.toByteArray())
+private fun encodeFrame(request: CountdownRequest): ByteArray = encodeTestFrame(request.toByteArray())
 
 private fun encodeJsonFrame(request: CountdownRequest): ByteArray {
     val printer = com.google.protobuf.util.JsonFormat.printer().omittingInsignificantWhitespace()
-    return frame(printer.print(request).toByteArray(Charsets.UTF_8))
-}
-
-private fun frame(payload: ByteArray): ByteArray = byteArrayOf(
-    0,
-    ((payload.size ushr 24) and 0xFF).toByte(),
-    ((payload.size ushr 16) and 0xFF).toByte(),
-    ((payload.size ushr 8) and 0xFF).toByte(),
-    (payload.size and 0xFF).toByte(),
-) + payload
-
-private fun decodeFrames(bytes: ByteArray): List<EnvelopeFrame> {
-    val frames = mutableListOf<EnvelopeFrame>()
-    var i = 0
-    while (i < bytes.size) {
-        if (i + ENVELOPE_HEADER_SIZE > bytes.size) error("truncated header at $i")
-        val flags = bytes[i]
-        val length = ((bytes[i + 1].toInt() and 0xFF) shl 24) or
-            ((bytes[i + 2].toInt() and 0xFF) shl 16) or
-            ((bytes[i + 3].toInt() and 0xFF) shl 8) or
-            (bytes[i + 4].toInt() and 0xFF)
-        if (i + ENVELOPE_HEADER_SIZE + length > bytes.size) {
-            error("truncated payload at $i: declared length $length exceeds remaining bytes")
-        }
-        val payload = bytes.copyOfRange(i + ENVELOPE_HEADER_SIZE, i + ENVELOPE_HEADER_SIZE + length)
-        frames.add(EnvelopeFrame(flags, payload))
-        i += ENVELOPE_HEADER_SIZE + length
-    }
-    return frames
+    return encodeTestFrame(printer.print(request).toByteArray(Charsets.UTF_8))
 }
 
 private fun HttpResponse.parseContentType(): ContentType? =

--- a/library/src/test/kotlin/io/github/ichizero/connect/ktor/streaming/HandleServerStreamTest.kt
+++ b/library/src/test/kotlin/io/github/ichizero/connect/ktor/streaming/HandleServerStreamTest.kt
@@ -4,8 +4,12 @@ import com.connectrpc.Code
 import com.connectrpc.ConnectException
 import com.stricteliza.v1.CountdownRequest
 import com.stricteliza.v1.CountdownResponse
+import com.stricteliza.v1.SayRequest
+import com.stricteliza.v1.SayResponse
 import com.stricteliza.v1.countdownRequest
 import com.stricteliza.v1.countdownResponse
+import com.stricteliza.v1.sayRequest
+import io.github.ichizero.ktor.protovalidate.ProtoRequestValidation
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.ktor.client.request.header
@@ -22,6 +26,7 @@ import io.ktor.server.application.ApplicationCall
 import io.ktor.server.application.install
 import io.ktor.server.resources.Resources
 import io.ktor.server.resources.post
+import io.ktor.server.routing.route
 import io.ktor.server.routing.routing
 import io.ktor.server.testing.testApplication
 import kotlinx.coroutines.flow.Flow
@@ -29,6 +34,79 @@ import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flow
 
 class HandleServerStreamTest : FunSpec({
+    test("server streaming: request validation respects the installed route and preserves details") {
+        var handled = 0
+        testApplication {
+            application {
+                install(Resources)
+                routing {
+                    for (validated in listOf(true, false)) {
+                        route(if (validated) "/validated" else "/unvalidated") {
+                            if (validated) install(ProtoRequestValidation)
+                            post<CountdownResource>(
+                                handleServerStream<CountdownResource, SayRequest, SayResponse>({ _, _ ->
+                                    handled++
+                                    emptyFlow()
+                                }),
+                            )
+                        }
+                    }
+                }
+            }
+            for (contentType in listOf(ConnectStreamingContentType.Proto, ConnectStreamingContentType.Json)) {
+                for ((prefix, length, rejected) in listOf(
+                    Triple("validated", 101, true),
+                    Triple("validated", 100, false),
+                    Triple("unvalidated", 101, false),
+                )) {
+                    val before = handled
+                    val request = sayRequest { sentence = "a".repeat(length) }
+                    val payload = if (contentType == ConnectStreamingContentType.Proto) {
+                        request.toByteArray()
+                    } else {
+                        com.google.protobuf.util.JsonFormat.printer().print(request).toByteArray(Charsets.UTF_8)
+                    }
+                    val response = client.post("/$prefix/stricteliza.v1.StrictElizaService/Countdown") {
+                        header(HttpHeaders.ContentType, contentType.toString())
+                        setBody(frame(payload))
+                    }
+                    response.status shouldBe HttpStatusCode.OK
+                    val frames = decodeFrames(response.bodyAsBytes())
+                    frames.size shouldBe 1
+                    frames.single().isEndStream shouldBe true
+                    val end = String(frames.single().payload)
+                    if (rejected) {
+                        handled shouldBe before
+                        end.contains("\"code\":\"invalid_argument\"") shouldBe true
+                        end.contains("buf.validate.Violation") shouldBe true
+                    } else {
+                        handled shouldBe before + 1
+                        end shouldBe "{}"
+                    }
+                }
+            }
+        }
+    }
+
+    test("server streaming: fatal handler errors reach the engine instead of an end frame") {
+        val response = postCountdown(
+            contentType = ConnectStreamingContentType.Proto,
+            body = encodeFrame(countdownRequest { from = 1 }),
+        ) { _, _ -> throw LinkageError("broken handler linkage") }
+        response.status shouldBe HttpStatusCode.InternalServerError
+    }
+
+    test("server streaming: fatal producer errors break the body instead of an end frame") {
+        val fatal = LinkageError("broken producer linkage")
+        val response = postCountdown(
+            contentType = ConnectStreamingContentType.Proto,
+            body = encodeFrame(countdownRequest { from = 1 }),
+        ) { _, _ -> flow<CountdownResponse> { throw fatal } }
+        // The test host has already committed the headers and exposes an empty body on writer failure.
+        // In particular, it must not contain a Connect UNKNOWN error or a successful end-stream frame.
+        response.bodyAsBytes().size shouldBe 0
+    }
+
     test("server streaming: 3 messages produce 3 data frames plus an end frame") {
         val response = postCountdown(
             contentType = ConnectStreamingContentType.Proto,
@@ -130,6 +208,25 @@ class HandleServerStreamTest : FunSpec({
         val frames = decodeFrames(response.bodyAsBytes())
         frames.size shouldBe 1
         String(frames[0].payload) shouldBe """{"error":{"code":"unknown","message":"boom"}}"""
+    }
+
+    test("server streaming: producer IOException terminates with an UNKNOWN end frame") {
+        val response = postCountdown(
+            contentType = ConnectStreamingContentType.Proto,
+            body = encodeFrame(countdownRequest { from = 1 }),
+        ) { _, _ ->
+            flow {
+                emit(countdownResponse { value = 1 })
+                throw java.io.IOException("upstream unavailable")
+            }
+        }
+
+        val frames = decodeFrames(response.bodyAsBytes())
+        frames.size shouldBe 2
+        CountdownResponse.parseFrom(frames.first().payload).value shouldBe 1
+        frames.last().isEndStream shouldBe true
+        String(frames.last().payload) shouldBe
+            """{"error":{"code":"unknown","message":"upstream unavailable"}}"""
     }
 
     test("server streaming: ConnectException.metadata is merged into end-stream trailers") {
@@ -242,7 +339,7 @@ class HandleServerStreamTest : FunSpec({
         val big = ByteArray(1024) { 'a'.code.toByte() }
         val response = postCountdown(
             contentType = ConnectStreamingContentType.Proto,
-            body = byteArrayOf(0x00, 0x00, 0x00, 0x00, big.size.toByte()) + big,
+            body = frame(big),
             maxMessageSize = 64,
         ) { _, _ -> emptyFlow() }
 

--- a/library/src/test/kotlin/io/github/ichizero/ktor/protovalidate/ProtoRequestValidationTest.kt
+++ b/library/src/test/kotlin/io/github/ichizero/ktor/protovalidate/ProtoRequestValidationTest.kt
@@ -1,6 +1,8 @@
 package io.github.ichizero.ktor.protovalidate
 
 import com.connectrpc.ResponseMessage
+import com.stricteliza.v1.CountdownRequest
+import com.stricteliza.v1.CountdownResponse
 import com.stricteliza.v1.SayRequest
 import com.stricteliza.v1.SayResponse
 import com.stricteliza.v1.StrictElizaServiceHandlerInterface
@@ -31,6 +33,7 @@ import io.ktor.server.routing.routing
 import io.ktor.server.testing.ApplicationTestBuilder
 import io.ktor.server.testing.testApplication
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
 
 object Handler : StrictElizaServiceHandlerInterface {
     override suspend fun say(
@@ -52,6 +55,11 @@ object Handler : StrictElizaServiceHandlerInterface {
         emptyMap(),
         emptyMap(),
     )
+
+    override suspend fun countdown(
+        request: CountdownRequest,
+        call: ApplicationCall,
+    ): Flow<CountdownResponse> = emptyFlow()
 }
 
 class ProtoRequestValidationTest : FunSpec({

--- a/library/src/test/kotlin/io/github/ichizero/protocgen/connect/ktor/GeneratorTest.kt
+++ b/library/src/test/kotlin/io/github/ichizero/protocgen/connect/ktor/GeneratorTest.kt
@@ -4,15 +4,20 @@ import com.connectrpc.ProtocolClientConfig
 import com.connectrpc.ResponseMessage
 import com.connectrpc.eliza.v1.ElizaServiceClient
 import com.connectrpc.eliza.v1.ElizaServiceHandlerInterface
+import com.connectrpc.eliza.v1.IntroduceRequest
+import com.connectrpc.eliza.v1.IntroduceResponse
 import com.connectrpc.eliza.v1.SayRequest
 import com.connectrpc.eliza.v1.SayResponse
 import com.connectrpc.eliza.v1.elizaService
+import com.connectrpc.eliza.v1.introduceRequest
+import com.connectrpc.eliza.v1.introduceResponse
 import com.connectrpc.eliza.v1.sayRequest
 import com.connectrpc.eliza.v1.sayResponse
 import com.connectrpc.extensions.GoogleJavaJSONStrategy
 import com.connectrpc.fold
 import com.connectrpc.impl.ProtocolClient
 import com.connectrpc.okhttp.ConnectOkHttpClient
+import io.github.ichizero.connect.ktor.streaming.connectResponseTrailers
 import io.github.ichizero.ktor.serialization.connect.connectJson
 import io.kotest.core.spec.style.*
 import io.kotest.matchers.*
@@ -23,6 +28,8 @@ import io.ktor.server.plugins.contentnegotiation.*
 import io.ktor.server.resources.*
 import io.ktor.server.routing.*
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 import okhttp3.OkHttpClient
 
 object Handler : ElizaServiceHandlerInterface {
@@ -36,6 +43,19 @@ object Handler : ElizaServiceHandlerInterface {
         emptyMap(),
         emptyMap(),
     )
+
+    override suspend fun introduce(
+        request: IntroduceRequest,
+        call: ApplicationCall,
+    ): Flow<IntroduceResponse> {
+        // Response headers go out with the HTTP head; trailers ride the end-stream frame.
+        call.response.headers.append("x-custom-header", "foo")
+        call.connectResponseTrailers().append("x-custom-trailer", "bing")
+        return flow {
+            emit(introduceResponse { sentence = "Hi ${request.name}!" })
+            emit(introduceResponse { sentence = "I'm Eliza." })
+        }
+    }
 }
 
 class GeneratorTest : FunSpec({
@@ -72,6 +92,41 @@ class GeneratorTest : FunSpec({
             onSuccess = { it shouldBe sayResponse { sentence = "Hi! Ktor Server" } },
             onFailure = { it shouldBe null },
         )
+
+        server.stop()
+    }
+
+    test("e2e server-streaming test with connect client") {
+        val server = embeddedServer(CIO, port = 0) {
+            startServer()
+        }
+        server.start(wait = false)
+        afterTest { server.stop() }
+        val port = server.engine.resolvedConnectors().first().port
+
+        val okHttpClient = OkHttpClient().newBuilder().build()
+        afterTest { okHttpClient.dispatcher.executorService.shutdown() }
+
+        val client = ProtocolClient(
+            httpClient = ConnectOkHttpClient(okHttpClient),
+            config = ProtocolClientConfig(
+                host = "http://localhost:$port",
+                serializationStrategy = GoogleJavaJSONStrategy(),
+                ioCoroutineContext = Dispatchers.IO,
+            ),
+        )
+
+        val stream = ElizaServiceClient(client).introduce()
+        stream.sendAndClose(introduceRequest { name = "Ktor" })
+
+        val sentences = mutableListOf<String>()
+        for (response in stream.responseChannel()) {
+            sentences += response.sentence
+        }
+
+        sentences shouldBe listOf("Hi Ktor!", "I'm Eliza.")
+        stream.responseHeaders().await()["x-custom-header"] shouldBe listOf("foo")
+        stream.responseTrailers().await()["x-custom-trailer"] shouldBe listOf("bing")
 
         server.stop()
     }

--- a/protoc-gen-connect-ktor/generator.go
+++ b/protoc-gen-connect-ktor/generator.go
@@ -12,13 +12,14 @@ import (
 
 // streamType mirrors Connect's StreamType vocabulary (see connect-go's connect.StreamType and
 // connect-kotlin's com.connectrpc.StreamType) for the RPC shapes connect-ktor currently knows
-// how to generate. Server-streaming and bidirectional streaming are reserved for future work;
-// methods of those kinds are skipped during generation.
+// how to generate. Bidirectional streaming is reserved for future work; methods of that kind are
+// skipped during generation.
 type streamType string
 
 const (
 	streamTypeUnary  streamType = "Unary"
 	streamTypeClient streamType = "Client"
+	streamTypeServer streamType = "Server"
 )
 
 // Run is the protogen entry point: it iterates the files marked for
@@ -62,15 +63,20 @@ func run(plugin *protogen.Plugin, file *protogen.File) error {
 func serviceToData(service *protogen.Service, protoPackageName, javaPackageName, sourceFileName string) *serviceData {
 	methods := make([]*methodData, 0, len(service.Methods))
 	hasClientStream := false
+	hasServerStream := false
 	hasGetRoute := false
 	for _, method := range service.Methods {
 		st, ok := streamTypeOf(method)
 		if !ok {
-			// Server-streaming / bidirectional streaming: skip for now.
+			// Bidirectional streaming: skip for now.
 			continue
 		}
-		if st == streamTypeClient {
+		switch st {
+		case streamTypeClient:
 			hasClientStream = true
+		case streamTypeServer:
+			hasServerStream = true
+		case streamTypeUnary:
 		}
 		noSideEffects := isNoSideEffects(method)
 		// Connect GET is emitted only for unary RPCs annotated NO_SIDE_EFFECTS
@@ -96,6 +102,7 @@ func serviceToData(service *protogen.Service, protoPackageName, javaPackageName,
 		Comment:          toKDocComment(service.Comments.Leading),
 		Methods:          methods,
 		HasClientStream:  hasClientStream,
+		HasServerStream:  hasServerStream,
 		HasGetRoute:      hasGetRoute,
 	}
 }
@@ -123,7 +130,7 @@ func idempotencyAllowsGet(level descriptorpb.MethodOptions_IdempotencyLevel) boo
 }
 
 // streamTypeOf returns the supported stream type and true, or (_, false) when the method is a
-// server-streaming or bidirectional RPC that we do not yet generate code for.
+// bidirectional RPC that we do not yet generate code for.
 func streamTypeOf(method *protogen.Method) (streamType, bool) {
 	return classifyStreamType(method.Desc.IsStreamingClient(), method.Desc.IsStreamingServer())
 }
@@ -136,6 +143,8 @@ func classifyStreamType(clientStream, serverStream bool) (streamType, bool) {
 		return streamTypeUnary, true
 	case clientStream && !serverStream:
 		return streamTypeClient, true
+	case !clientStream && serverStream:
+		return streamTypeServer, true
 	default:
 		return "", false
 	}

--- a/protoc-gen-connect-ktor/generator_test.go
+++ b/protoc-gen-connect-ktor/generator_test.go
@@ -77,10 +77,11 @@ func Test_classifyStreamType(t *testing.T) {
 			describesShape: "stream Req -> Res",
 		},
 		{
-			name:           "server streaming (unsupported)",
+			name:           "server streaming",
 			clientStream:   false,
 			serverStream:   true,
-			wantSupported:  false,
+			wantType:       streamTypeServer,
+			wantSupported:  true,
 			describesShape: "Req -> stream Res",
 		},
 		{
@@ -154,6 +155,29 @@ func Test_template_unaryOnly(t *testing.T) {
 	mustContain(t, out, "post<ExampleHandlerInterface.Procedures.Say, SayRequest>(handle(handler::say))")
 	mustNotContain(t, out, "kotlinx.coroutines.flow.Flow")
 	mustNotContain(t, out, "handleClientStream")
+	mustNotContain(t, out, "handleServerStream")
+}
+
+// Test_template_serverStream verifies that a server-streaming method returns a Flow and is
+// dispatched through handleServerStream, without dragging in the client-streaming import.
+func Test_template_serverStream(t *testing.T) {
+	t.Parallel()
+	out := renderTemplate(t, &serviceData{
+		ProtoPackageName: "example.v1",
+		JavaPackageName:  "com.example.v1",
+		SourceFileName:   "example/v1/example.proto",
+		Name:             "Example",
+		Methods: []*methodData{
+			{Name: "Tail", InputTypeName: "TailRequest", OutputTypeName: "TailResponse", StreamType: streamTypeServer},
+		},
+		HasServerStream: true,
+	})
+
+	mustContain(t, out, "import kotlinx.coroutines.flow.Flow")
+	mustContain(t, out, "import io.github.ichizero.connect.ktor.streaming.handleServerStream")
+	mustContain(t, out, "suspend fun tail(request: TailRequest, call: ApplicationCall): Flow<TailResponse>")
+	mustContain(t, out, "post<ExampleHandlerInterface.Procedures.Tail>(handleServerStream(handler::tail))")
+	mustNotContain(t, out, "handleClientStream")
 }
 
 // Test_template_mixedKinds verifies a service with both unary and client-streaming methods
@@ -178,6 +202,7 @@ func Test_template_mixedKinds(t *testing.T) {
 	mustContain(t, out, "post<ExampleHandlerInterface.Procedures.Upload>(handleClientStream(handler::upload))")
 	// unary entry remains unchanged.
 	mustContain(t, out, "post<ExampleHandlerInterface.Procedures.Say, SayRequest>(handle(handler::say))")
+	mustNotContain(t, out, "handleServerStream")
 }
 
 func renderTemplate(t *testing.T, data *serviceData) string {

--- a/protoc-gen-connect-ktor/template.go
+++ b/protoc-gen-connect-ktor/template.go
@@ -21,6 +21,9 @@ type serviceData struct {
 	// HasClientStream is true when any of Methods has StreamType == streamTypeClient.
 	// Drives conditional imports for Flow / handleClientStream.
 	HasClientStream bool
+	// HasServerStream is true when any of Methods has StreamType == streamTypeServer.
+	// Drives conditional imports for Flow / handleServerStream.
+	HasServerStream bool
 	// HasGetRoute is true when the service emits at least one Connect GET route,
 	// i.e. it has a unary method whose NoSideEffects is true. Drives conditional
 	// imports for handleGet / io.ktor.server.resources.get.
@@ -51,6 +54,9 @@ import io.github.ichizero.connect.ktor.handle
 {{- if .HasClientStream }}
 import io.github.ichizero.connect.ktor.streaming.handleClientStream
 {{- end }}
+{{- if .HasServerStream }}
+import io.github.ichizero.connect.ktor.streaming.handleServerStream
+{{- end }}
 {{- if .HasGetRoute }}
 import io.github.ichizero.connect.ktor.handleGet
 {{- end }}
@@ -61,7 +67,7 @@ import io.ktor.server.resources.get
 {{- end }}
 import io.ktor.server.resources.post
 import io.ktor.server.routing.Route
-{{- if .HasClientStream }}
+{{- if or .HasClientStream .HasServerStream }}
 import kotlinx.coroutines.flow.Flow
 {{- end }}
 
@@ -73,6 +79,8 @@ interface {{ .Name }}HandlerInterface {
     suspend fun {{ .Name | toLowerFirst }}(request: {{ .InputTypeName }}, call: ApplicationCall): ResponseMessage<{{ .OutputTypeName }}>
     {{- else if eq (printf "%s" .StreamType) "Client" }}
     suspend fun {{ .Name | toLowerFirst }}(requests: Flow<{{ .InputTypeName }}>, call: ApplicationCall): ResponseMessage<{{ .OutputTypeName }}>
+    {{- else if eq (printf "%s" .StreamType) "Server" }}
+    suspend fun {{ .Name | toLowerFirst }}(request: {{ .InputTypeName }}, call: ApplicationCall): Flow<{{ .OutputTypeName }}>
     {{- end }}
     {{- end }}
 
@@ -93,6 +101,8 @@ fun Route.{{ .Name | toLowerFirst }}(handler: {{ .Name }}HandlerInterface) {
     {{- end }}
     {{- else if eq (printf "%s" .StreamType) "Client" }}
     post<{{ $.Name }}HandlerInterface.Procedures.{{ .Name }}>(handleClientStream(handler::{{ .Name | toLowerFirst }}))
+    {{- else if eq (printf "%s" .StreamType) "Server" }}
+    post<{{ $.Name }}HandlerInterface.Procedures.{{ .Name }}>(handleServerStream(handler::{{ .Name | toLowerFirst }}))
     {{- end }}
     {{- end }}
 }

--- a/protoc-gen-connect-ktor/template.go
+++ b/protoc-gen-connect-ktor/template.go
@@ -75,11 +75,11 @@ import kotlinx.coroutines.flow.Flow
 interface {{ .Name }}HandlerInterface {
     {{- range .Methods }}
     {{- .Comment | nIndent 4 -}}
-    {{- if eq (printf "%s" .StreamType) "Unary" }}
+    {{- if eq .StreamType "Unary" }}
     suspend fun {{ .Name | toLowerFirst }}(request: {{ .InputTypeName }}, call: ApplicationCall): ResponseMessage<{{ .OutputTypeName }}>
-    {{- else if eq (printf "%s" .StreamType) "Client" }}
+    {{- else if eq .StreamType "Client" }}
     suspend fun {{ .Name | toLowerFirst }}(requests: Flow<{{ .InputTypeName }}>, call: ApplicationCall): ResponseMessage<{{ .OutputTypeName }}>
-    {{- else if eq (printf "%s" .StreamType) "Server" }}
+    {{- else if eq .StreamType "Server" }}
     suspend fun {{ .Name | toLowerFirst }}(request: {{ .InputTypeName }}, call: ApplicationCall): Flow<{{ .OutputTypeName }}>
     {{- end }}
     {{- end }}
@@ -94,14 +94,14 @@ interface {{ .Name }}HandlerInterface {
 
 fun Route.{{ .Name | toLowerFirst }}(handler: {{ .Name }}HandlerInterface) {
     {{- range .Methods }}
-    {{- if eq (printf "%s" .StreamType) "Unary" }}
+    {{- if eq .StreamType "Unary" }}
     post<{{ $.Name }}HandlerInterface.Procedures.{{ .Name }}, {{ .InputTypeName }}>(handle(handler::{{ .Name | toLowerFirst }}))
     {{- if .NoSideEffects }}
     get<{{ $.Name }}HandlerInterface.Procedures.{{ .Name }}>(handleGet<{{ $.Name }}HandlerInterface.Procedures.{{ .Name }}, {{ .InputTypeName }}, {{ .OutputTypeName }}>(handler::{{ .Name | toLowerFirst }}))
     {{- end }}
-    {{- else if eq (printf "%s" .StreamType) "Client" }}
+    {{- else if eq .StreamType "Client" }}
     post<{{ $.Name }}HandlerInterface.Procedures.{{ .Name }}>(handleClientStream(handler::{{ .Name | toLowerFirst }}))
-    {{- else if eq (printf "%s" .StreamType) "Server" }}
+    {{- else if eq .StreamType "Server" }}
     post<{{ $.Name }}HandlerInterface.Procedures.{{ .Name }}>(handleServerStream(handler::{{ .Name | toLowerFirst }}))
     {{- end }}
     {{- end }}


### PR DESCRIPTION
## 背景

connect-ktor はこれまで unary と client-streaming のみをサポートしており、`protoc-gen-connect-ktor` は `IsStreamingServer()` なメソッドを丸ごとスキップしていました。server-streaming はログ tailing・進捗通知・チャンク分割レスポンスなど利用頻度が高く、Connect サーバー実装としてのパリティに必要です。

client-streaming (#192) が envelope framing / end-stream frame / streaming codec の基盤を導入済みなので、本 PR はその機構を逆方向（サーバー → クライアント）へ再利用しています。追加した公開 API は `handleServerStream` と `call.connectResponseTrailers()` の 2 つだけです。

Closes #187

## 変更内容

### protoc-gen-connect-ktor

`rpc X(Req) returns (stream Res)` を第 3 のストリーム種別として分類し、以下を生成します。

```kotlin
suspend fun introduce(request: IntroduceRequest, call: ApplicationCall): Flow<IntroduceResponse>
// post<Procedures.Introduce>(handleServerStream(handler::introduce))
```

スキップ対象として残るのは bidi のみです。

### library: `handleServerStream`

- リクエストボディはデータフレーム 1 個。0 個・2 個以上は connect-go の server-stream ハンドラーと同じく `UNIMPLEMENTED`、圧縮ネゴシエーション無しの compressed フレームは `INTERNAL` として扱います（いずれも conformance の `Connect Unexpected Requests` が期待値を固定しています）。
- `Flow` が emit した各メッセージを 1 データフレームとして書き出し、都度 flush します。**最初のメッセージより先にレスポンスヘッダーをフラッシュ**するので、producer が遅くてもクライアントがヘッダー読み取りでブロックしません（connect-go が server stream 開始時に空送信するのと同じ意図）。
- 正常完了でストリーム終了、`ConnectException` throw で end-stream frame の `error` になり、その `metadata` は trailers にマージされます。

### trailers の表現

trailers は HTTP ヘッダーとして送れず、`Flow<Res>` にも載せる場所がありません。一方 conformance の `Basic/server-stream/success` や `Duplicate Metadata/server-stream/*` は**成功時にも** trailers のエコーバックを要求します。そこで call スコープの `call.connectResponseTrailers()`（Ktor `HeadersBuilder`）を追加し、end-stream frame 書き込み時にスナップショットを読む形にしました。ヘッダーは従来どおり `call.response.headers` に積みます。

戻り値を `ServerStreamResponse<Res>` のようなラッパー型にする案もありましたが、issue 記載のハンドラーシグネチャ（`Flow<Res>`）を保つ方を選んでいます。

### キャンセル伝播

`CancellationException` と書き込みチャネル破断（`IOException`）は end-stream frame に変換せずそのまま伝播させます。飲み込むと、クライアントが去った後もハンドラーの `Flow` collector とそれが握るリソースが生き続けるためです。実 CIO エンジン + 生ソケットを RST で切断するテスト（`HandleServerStreamCancellationTest`）で、collector の `finally` が走ることを検証しています。

### deadline

`Connect-Timeout-Ms` は「リクエスト読み取り + ハンドラー起動」と「ストリーミング」の 2 フェーズを**単一の monotonic deadline** で束ねます。フェーズごとに `withTimeout` を張ると各々が満額の budget を持ててしまうためです。満了は `DEADLINE_EXCEEDED` の end-stream frame として返します。

## conformance

`STREAM_TYPE_SERVER_STREAM` を cio / netty 両方で有効化し、reference server に倣って `ServerStream` を実装しました（headers/trailers は flow 収集前に設定、`response_delay_ms` はメッセージごと、`request_info` は先頭メッセージのみ、メッセージ 0 件でエラー時のみ error details に `request_info` を格納）。

**結果: cio 209 passed / 0 failed、netty 976 passed / 0 failed。**

新規 pin はいずれも server-streaming の欠陥ではなく既知のギャップです。

- gzip streaming ケース（per-message compression 未実装 / #190）
- `Server Message Size`（`connectBodyLimit` は body 全体キャップで、per-message receive limit ではない）
- CIO のみ: request_info が重複リクエストヘッダーをエコーするケース（CIO 上流の制約）

`Duplicate Metadata/**` はストリーム種別ごとに分割しました。新しく走る `server-stream/no-response` は重複ヘッダーを送らないため CIO でも pass し、包括 glob のままだと "expected to fail but did not" になるためです。

## 破壊的変更（生成コード）

`.proto` に server-streaming メソッドを持つサービスでは、生成される handler interface に新しいメンバーが増えます（これまではスキップされていたため）。実装側で `override` の追加が必要です。

## 補足（このPRのスコープ外）

`handleClientStream` は compressed フレームを `UNIMPLEMENTED` として扱っており、本 PR で server-stream 側に入れた `INTERNAL`（プロトコルエラー）とは挙動が異なります。client-stream 側は conformance に該当ケースが無く、既存挙動の変更になるため触っていません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Connect server-streaming RPC support for CIO and Netty.
  * Generated server-streaming handlers now return Kotlin `Flow` responses.
  * Added streaming response headers, trailers, errors, deadlines, and cancellation handling.
  * Added the `Countdown` server-streaming example RPC.

* **Documentation**
  * Updated guides, feature lists, conformance results, and known limitations for server streaming.
  * Clarified that bidirectional streaming remains unsupported and streaming gzip has limitations.

* **Tests**
  * Added coverage for framing, metadata, failures, limits, timeouts, and client disconnects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->