### PR TITLE
ci: auto-fix pnpm-lock.yaml catalog drift on dependabot PRs

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -2,6 +2,65 @@ name: Dependabot auto-merge
 on: pull_request
 permissions: {}
 jobs:
+  fix-pnpm-lockfile-drift:
+    # Dependabot's pnpm updater can write a resolved version into
+    # pnpm-lock.yaml instead of preserving the pnpm-workspace.yaml catalog
+    # specifier, which breaks `pnpm install --frozen-lockfile` in CI.
+    # See https://github.com/dependabot/dependabot-core/issues/12244
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'ichizero/connect-ktor'
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Dependabot metadata
+        id: dependabot-metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+
+      - name: Checkout PR branch
+        if: steps.dependabot-metadata.outputs.package-ecosystem == 'npm_and_yarn'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          # Falls back to GITHUB_TOKEN if no PAT is configured. A PAT/App
+          # token is needed for the resulting push to re-trigger the other
+          # required checks (GITHUB_TOKEN pushes don't trigger workflows).
+          token: ${{ secrets.DEPENDABOT_LOCKFILE_PAT || secrets.GITHUB_TOKEN }}
+          persist-credentials: true
+
+      - uses: pnpm/setup@4700d737c3d7a2e7199f3d42a920f0bf7f34e411 # v2.0.1
+        if: steps.dependabot-metadata.outputs.package-ecosystem == 'npm_and_yarn'
+        with:
+          install: false
+
+      - name: Reconcile pnpm-lock.yaml with pnpm-workspace.yaml catalog
+        if: steps.dependabot-metadata.outputs.package-ecosystem == 'npm_and_yarn'
+        id: fix
+        run: |
+          set -euo pipefail
+          pnpm install --no-frozen-lockfile
+          if git diff --quiet -- pnpm-lock.yaml; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add pnpm-lock.yaml
+          git commit -m "chore: reconcile pnpm-lock.yaml catalog specifiers"
+          git push origin "HEAD:$PR_HEAD_REF"
+        env:
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+
+      - name: Comment about the drift fix
+        if: steps.dependabot-metadata.outputs.package-ecosystem == 'npm_and_yarn' && steps.fix.outputs.changed == 'true'
+        run: |
+          gh pr comment "$PR_URL" --body "pnpm-lock.yaml had a catalog specifier out of sync with pnpm-workspace.yaml (a known dependabot-core bug, see [dependabot/dependabot-core#12244](https://github.com/dependabot/dependabot-core/issues/12244)). Pushed a fix commit. If checks don't automatically restart on the new commit, re-run them manually."
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   dependabot:
     runs-on: ubuntu-latest
     if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'ichizero/connect-ktor'


### PR DESCRIPTION
## Summary

#300 (`chore(deps): Bump the docs-site group...`) was blocked because `pnpm-lock.yaml` had `tegami`'s `specifier` written as a literal `1.3.3` instead of the `catalog:` reference declared in `package.json`. `pnpm install --frozen-lockfile` (run implicitly by `pnpm/setup`) then fails with `ERR_PNPM_OUTDATED_LOCKFILE`, keeping the PR unmergeable until someone manually regenerates the lockfile (as done for #300).

This is a known, still-open upstream bug in `dependabot-core` — it can write a resolved version into `pnpm-lock.yaml` instead of preserving the `pnpm-workspace.yaml` catalog specifier for a bumped dependency ([dependabot/dependabot-core#12244](https://github.com/dependabot/dependabot-core/issues/12244), related: [#11953](https://github.com/dependabot/dependabot-core/issues/11953), [#14339](https://github.com/dependabot/dependabot-core/issues/14339)). There is no `dependabot.yml` setting that avoids it.

This PR adds a CI job that detects and self-heals that drift on dependabot npm PRs, so it doesn't need manual intervention every time.

## What changed

- `.github/workflows/dependabot.yml`
  - New `fix-pnpm-lockfile-drift` job, gated to dependabot PRs on the `npm_and_yarn` ecosystem:
    - Checks out the PR's head branch.
    - Runs `pnpm install --no-frozen-lockfile` to reconcile the lockfile against `pnpm-workspace.yaml`.
    - If `pnpm-lock.yaml` changed, commits and pushes the fix back to the PR branch, then leaves a short PR comment explaining what happened.

## Decision points

| Question | Decision | Why |
| -------- | -------- | --- |
| Fix via repo/dependabot config, or via CI automation? | CI automation | The bug is in `dependabot-core` itself; there is no known `dependabot.yml` option that prevents it. |
| How does the push get pushed back to the PR branch? | `contents: write` job permission + `actions/checkout` with `persist-credentials: true`, same pattern as the existing `dependabot` auto-merge job | Dependabot branches live in this repo (not a fork), so the default `GITHUB_TOKEN` can push directly when the workflow explicitly grants `contents: write`. |
| Will the fix-up push automatically re-run the other required checks (`ci`, `docs-site`)? | Not guaranteed with the default `GITHUB_TOKEN` | GitHub doesn't trigger new workflow runs from pushes made with the default `GITHUB_TOKEN`, to prevent recursive triggers. The job optionally uses a `DEPENDABOT_LOCKFILE_PAT` secret (falls back to `GITHUB_TOKEN`) — set that secret (a PAT/App token with `contents: write`) if you want the fix-up push to auto re-trigger CI; otherwise the PR comment tells you to re-run checks manually. |
| Why only target `npm_and_yarn`? | `if: steps.dependabot-metadata.outputs.package-ecosystem == 'npm_and_yarn'` on each step | This drift is specific to pnpm workspace catalogs; other ecosystems (gradle, gomod, github-actions) aren't affected. |

## Commits

| Commit | Purpose |
| ------ | ------- |
| `29a87d8 ci: auto-fix pnpm-lock.yaml catalog drift on dependabot PRs` | Adds the `fix-pnpm-lockfile-drift` job |

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — workflow YAML parses
- [x] `zizmor --offline .github/workflows/` — no new findings vs. `main` (0 findings either way)
- [x] Reproduced the exact failure locally against #300's branch (`ERR_PNPM_OUTDATED_LOCKFILE: tegami lockfile: 1.3.3, manifest: catalog:`) and confirmed `pnpm install --no-frozen-lockfile` is the correct fix (used manually to unblock #300)
- [ ] End-to-end verification on a real dependabot PR (can't run a `pull_request` workflow locally) — recommend watching the next dependabot npm PR that touches `pnpm-lock.yaml`


---
_Generated by [Claude Code](https://claude.ai/code/session_01LKrFjK6a9RSja2UjjaR9fq)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated dependency update handling by reconciling lockfile changes when needed.
  * Added notifications when lockfile corrections are applied to dependency update requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->