### PR TITLE
docs(changelog): add pending deps entry for post-v0.3.0 bot merges

### DIFF
--- a/.tegami/2026-08-31-deps.md
+++ b/.tegami/2026-08-31-deps.md
@@ -1,0 +1,41 @@
+---
+packages:
+    connect-ktor: patch
+---
+
+## Dependencies
+
+- chore(deps): Bump pnpm/action-setup from 4.2.0 to 6.0.9 by @dependabot[bot] in [PR #280](https://github.com/ichizero/connect-ktor/pull/280)
+- chore(deps): Bump lucide-react from 1.26.0 to 1.27.0 in the docs-site group by @dependabot[bot] in [PR #279](https://github.com/ichizero/connect-ktor/pull/279)
+- chore(deps): Bump spotless from 8.8.0 to 8.9.0 by @dependabot[bot] in [PR #282](https://github.com/ichizero/connect-ktor/pull/282)
+- chore(deps): Bump com.squareup.okio:okio from 3.18.0 to 3.18.1 by @dependabot[bot] in [PR #283](https://github.com/ichizero/connect-ktor/pull/283)
+- chore(deps): Bump actions/attest from 4.2.0 to 4.2.1 by @dependabot[bot] in [PR #284](https://github.com/ichizero/connect-ktor/pull/284)
+- chore(deps): Bump the codeql-action group with 3 updates by @dependabot[bot] in [PR #285](https://github.com/ichizero/connect-ktor/pull/285)
+- chore(deps): Bump actions/setup-java from 5.6.0 to 5.7.0 by @dependabot[bot] in [PR #287](https://github.com/ichizero/connect-ktor/pull/287)
+- chore(deps): Bump lucide-react from 1.27.0 to 1.28.0 in the docs-site group by @dependabot[bot] in [PR #286](https://github.com/ichizero/connect-ktor/pull/286)
+- chore(deps): Bump ktor from 3.5.1 to 3.5.2 by @dependabot[bot] in [PR #288](https://github.com/ichizero/connect-ktor/pull/288)
+- chore(deps): Bump the codeql-action group with 3 updates by @dependabot[bot] in [PR #290](https://github.com/ichizero/connect-ktor/pull/290)
+- chore(deps): Bump zizmorcore/zizmor-action from 0.6.1 to 0.6.2 by @dependabot[bot] in [PR #291](https://github.com/ichizero/connect-ktor/pull/291)
+- chore(deps): Bump gradle/actions/wrapper-validation from 6.2.0 to 6.3.0 by @dependabot[bot] in [PR #293](https://github.com/ichizero/connect-ktor/pull/293)
+- chore(deps): Bump jdx/mise-action from 4.2.3 to 4.2.4 by @dependabot[bot] in [PR #292](https://github.com/ichizero/connect-ktor/pull/292)
+- chore(deps): Bump actions/attest from 4.2.1 to 4.2.2 by @dependabot[bot] in [PR #296](https://github.com/ichizero/connect-ktor/pull/296)
+- chore(deps): Bump the codeql-action group with 3 updates by @dependabot[bot] in [PR #295](https://github.com/ichizero/connect-ktor/pull/295)
+- chore(deps): Bump pnpm/setup from 2.0.0 to 2.0.1 by @dependabot[bot] in [PR #301](https://github.com/ichizero/connect-ktor/pull/301)
+- chore(deps): Bump jdx/mise-action from 4.2.4 to 4.2.5 by @dependabot[bot] in [PR #310](https://github.com/ichizero/connect-ktor/pull/310)
+- chore(deps): Bump org.cyclonedx.bom from 3.3.0 to 3.4.1 by @dependabot[bot] in [PR #308](https://github.com/ichizero/connect-ktor/pull/308)
+- chore(deps): Bump the codeql-action group with 3 updates by @dependabot[bot] in [PR #309](https://github.com/ichizero/connect-ktor/pull/309)
+- chore(deps): Bump the docs-site group across 1 directory with 8 updates by @dependabot[bot] in [PR #305](https://github.com/ichizero/connect-ktor/pull/305)
+- chore(deps): Bump google.golang.org/protobuf from 1.36.11 to 1.36.12 in /protoc-gen-connect-ktor by @dependabot[bot] in [PR #307](https://github.com/ichizero/connect-ktor/pull/307)
+- chore(deps): Bump org.junit.jupiter:junit-jupiter-engine from 6.1.2 to 6.1.3 by @dependabot[bot] in [PR #303](https://github.com/ichizero/connect-ktor/pull/303)
+- chore(deps): Bump pnpm/setup from 2.0.1 to 2.0.2 by @dependabot[bot] in [PR #304](https://github.com/ichizero/connect-ktor/pull/304)
+- chore(deps): update docs-site by @renovate[bot] in [PR #313](https://github.com/ichizero/connect-ktor/pull/313)
+- chore(deps): update pnpm to v11.22.0 by @renovate[bot] in [PR #317](https://github.com/ichizero/connect-ktor/pull/317)
+- fix(deps): update dependency com.squareup.okhttp3:okhttp to v5.5.0 by @renovate[bot] in [PR #318](https://github.com/ichizero/connect-ktor/pull/318)
+- chore(deps): update dependency go to v1.27.0 by @renovate[bot] in [PR #320](https://github.com/ichizero/connect-ktor/pull/320)
+- chore(deps): update docs-site by @renovate[bot] in [PR #319](https://github.com/ichizero/connect-ktor/pull/319)
+- chore(deps): update gradle to v9.7.1 by @renovate[bot] in [PR #314](https://github.com/ichizero/connect-ktor/pull/314)
+- chore(deps): update dependency lefthook to v2.1.11 by @renovate[bot] in [PR #321](https://github.com/ichizero/connect-ktor/pull/321)
+- chore(deps): update github/codeql-action action to v4.37.8 by @renovate[bot] in [PR #322](https://github.com/ichizero/connect-ktor/pull/322)
+- fix(deps): update kotest to v6 by @renovate[bot] in [PR #316](https://github.com/ichizero/connect-ktor/pull/316)
+- chore(deps): update dependency golangci-lint to v2.13.1 by @renovate[bot] in [PR #323](https://github.com/ichizero/connect-ktor/pull/323)
+- chore(deps): update docs-site by @renovate[bot] in [PR #324](https://github.com/ichizero/connect-ktor/pull/324)


### PR DESCRIPTION
## Summary

Renovate/Dependabot merges have piled up since `v0.3.0` (2026-08-02) with no pending Tegami entry, so the next release would ship them with an empty changelog. This adds the missing dependency-only entry so the next Version Packages PR bumps `connect-ktor` to a patch release and publishes the bump list. Follows the "Dependency-only releases" procedure in `CONTRIBUTING.md`; no source or workflow changes.

## What changed

- `.tegami/2026-08-31-deps.md` (new)
    - Frontmatter `packages.connect-ktor: patch`, body is a single `## Dependencies` section
    - 34 bullets covering every bot dependency PR merged after the `v0.3.0` tag: Dependabot #279–#310 (23) and Renovate #313–#324 (11)
    - Line format matches `scripts/tegami-deps-summary.sh` output (`<PR title> by @<bot> in [PR #N](url)`), with `-` bullets to match the published `apps/docs-site/changelog/2026-08-02-dependencies.mdx`

## Decision points

| Question | Decision | Why |
| -------- | -------- | --- |
| `gh` CLI is unavailable in this environment, so `pnpm tegami:deps-summary` cannot run | Reproduced the script's logic through the GitHub API instead | Same filter (authors `app/dependabot` / `app/renovate`, `mergedAt` after the `v0.3.0` tag, `chore(deps)`/`Bump` titles) and same output shape, so the result is identical to what the script would emit. |
| #314's squashed commit subject says `update gradle to v9.7.0`, but the PR title says v9.7.1 | Used the PR title (v9.7.1) | `gradle/wrapper/gradle-wrapper.properties` is on `gradle-9.7.1-bin.zip`; the commit subject is stale, and the script sources titles from the PR anyway. |
| Include the follow-up commit `fix(deps): drop kotest-framework-datatest ...`? | No separate bullet | It is part of PR #316 (`fix(deps): update kotest to v6`), which already has a bullet. |
| Bump type for entries touching runtime deps (ktor, okhttp) | `patch` | Matches `CONTRIBUTING.md` guidance for dependency-only releases and the previous `2026-08-02-dependencies.md` entry, which also carried a ktor bump. |

## Commits

| Commit | Purpose |
| ------ | ------- |
| `docs(changelog): add pending deps entry for post-v0.3.0 Renovate/Dependabot merges` | Adds the pending `.tegami/` entry covering #279–#324. |

## Test plan

- [x] `pnpm exec oxfmt .tegami/2026-08-31-deps.md` — no reformatting needed
- [x] Entry parses through the Tegami API (`tegami({...}).draft()` picks up the file with its frontmatter and body)
- [x] Bump list cross-checked against `git log v0.3.0..HEAD` — every bot PR in the range has a bullet, and no PR merged before the tag is included
- [ ] `tegami-pr` release preview comment on this PR shows `connect-ktor` bumping 0.3.0 → 0.3.1 with the `## Dependencies` section
- [ ] After merge, `release.yml` opens/updates the Version Packages PR with the entry

---
_Generated by [Claude Code](https://claude.ai/code/session_01DHaEcuXfFFveg43B92nFXk)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the `connect-ktor` package to a new patch release.
  * Refreshed numerous tooling, documentation, runtime, testing, and build dependencies.
  * Updated related automation and development tools to newer versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->