### PR TITLE
docs(changelog): add #327/#328 to pending deps entry, indent markdown at 2 spaces

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,6 +9,11 @@ max_line_length = 120
 [*.{json,yaml,yml}]
 indent_size = 2
 
+# Tegami writes YAML frontmatter at its own 2-space default, both for
+# .tegami/*.md and the generated apps/docs-site/changelog/*.mdx.
+[*.{md,mdx}]
+indent_size = 2
+
 [*.{kt,kts}]
 ktlint_standard_class-signature = disabled
 ktlint_standard_function-signature = disabled

--- a/.tegami/2026-08-31-deps.md
+++ b/.tegami/2026-08-31-deps.md
@@ -39,3 +39,5 @@ packages:
 - fix(deps): update kotest to v6 by @renovate[bot] in [PR #316](https://github.com/ichizero/connect-ktor/pull/316)
 - chore(deps): update dependency golangci-lint to v2.13.1 by @renovate[bot] in [PR #323](https://github.com/ichizero/connect-ktor/pull/323)
 - chore(deps): update docs-site by @renovate[bot] in [PR #324](https://github.com/ichizero/connect-ktor/pull/324)
+- chore(deps): update docs-site by @renovate[bot] in [PR #327](https://github.com/ichizero/connect-ktor/pull/327)
+- fix(deps): update protobuf monorepo to v4.36.0 by @renovate[bot] in [PR #328](https://github.com/ichizero/connect-ktor/pull/328)

--- a/.tegami/2026-08-31-deps.md
+++ b/.tegami/2026-08-31-deps.md
@@ -1,6 +1,6 @@
 ---
 packages:
-    connect-ktor: patch
+  connect-ktor: patch
 ---
 
 ## Dependencies

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ Or create `.tegami/YYYY-MM-DD-<id>.md` by hand (see
 ```md
 ---
 packages:
-    connect-ktor: minor
+  connect-ktor: minor
 ---
 
 ## Support example feature
@@ -97,12 +97,17 @@ Rules:
 - YAML frontmatter must include `packages` with an explicit bump:
   `major` | `minor` | `patch` (this repo uses **explicit** style; see
   `scripts/tegami.mts`)
+- Frontmatter is indented with **2 spaces**. Tegami writes YAML at its own
+  2-space default for both `.tegami/*.md` and the generated
+  `apps/docs-site/changelog/*.mdx`, so `.editorconfig` sets `indent_size = 2`
+  for `*.md` / `*.mdx`; without it `lint-format` fails on the changelog files
+  the release workflow generates
 - Body is **freeform Markdown**. Do **not** add Changesets-style category headings
   such as `## Features` / `## Fixes`
 - Convention for each change:
-    1. `##` (h2) title
-    2. Brief user-facing description
-    3. PR reference: `PR #123` or `[PR #123](https://github.com/ichizero/connect-ktor/pull/123)`
+  1. `##` (h2) title
+  2. Brief user-facing description
+  3. PR reference: `PR #123` or `[PR #123](https://github.com/ichizero/connect-ktor/pull/123)`
 - Body needs at least one `#` / `##` / `###` heading (Tegami requirement)
 - Write notes for end users (not internal refactor chatter)
 - Package name is `connect-ktor` (Gradle package)
@@ -129,7 +134,7 @@ shorten PR refs to `[PR #N](...)`:
 ```md
 ---
 packages:
-    connect-ktor: patch
+  connect-ktor: patch
 ---
 
 ## Dependencies

--- a/README.md
+++ b/README.md
@@ -73,14 +73,14 @@ Install the generator (`brew install ichizero/tap/protoc-gen-connect-ktor` or a
 ```yaml
 # buf.gen.yaml (excerpt)
 plugins:
-    - remote: buf.build/protocolbuffers/java
-      out: path/to/code
-    - remote: buf.build/protocolbuffers/kotlin
-      out: path/to/code
-    - remote: buf.build/connectrpc/kotlin
-      out: path/to/code
-    - local: protoc-gen-connect-ktor
-      out: path/to/code
+  - remote: buf.build/protocolbuffers/java
+    out: path/to/code
+  - remote: buf.build/protocolbuffers/kotlin
+    out: path/to/code
+  - remote: buf.build/connectrpc/kotlin
+    out: path/to/code
+  - local: protoc-gen-connect-ktor
+    out: path/to/code
 ```
 
 ```bash

--- a/apps/docs-site/changelog/2024-10-27-v0.0.1.mdx
+++ b/apps/docs-site/changelog/2024-10-27-v0.0.1.mdx
@@ -2,8 +2,8 @@
 title: Implement protoc-gen-connect-ktor
 date: 2024-10-27T21:43:04.000Z
 packages:
-    connect-ktor:
-        version: 0.0.1
+  connect-ktor:
+    version: 0.0.1
 ---
 
 ## Implement protoc-gen-connect-ktor

--- a/apps/docs-site/changelog/2024-11-06-v0.0.2.mdx
+++ b/apps/docs-site/changelog/2024-11-06-v0.0.2.mdx
@@ -2,8 +2,8 @@
 title: Add support for proto serialization/deserialization
 date: 2024-11-06T14:40:42.000Z
 packages:
-    connect-ktor:
-        version: 0.0.2
+  connect-ktor:
+    version: 0.0.2
 ---
 
 ## Add support for proto serialization/deserialization

--- a/apps/docs-site/changelog/2024-12-15-v0.0.3.mdx
+++ b/apps/docs-site/changelog/2024-12-15-v0.0.3.mdx
@@ -2,8 +2,8 @@
 title: Add validation plugin with protovalidate
 date: 2024-12-15T18:12:49.000Z
 packages:
-    connect-ktor:
-        version: 0.0.3
+  connect-ktor:
+    version: 0.0.3
 ---
 
 ## Add validation plugin with protovalidate

--- a/apps/docs-site/changelog/2025-02-11-v0.0.4.mdx
+++ b/apps/docs-site/changelog/2025-02-11-v0.0.4.mdx
@@ -2,8 +2,8 @@
 title: Dependency updates
 date: 2025-02-11T14:12:08.000Z
 packages:
-    connect-ktor:
-        version: 0.0.4
+  connect-ktor:
+    version: 0.0.4
 ---
 
 ## Dependencies

--- a/apps/docs-site/changelog/2025-02-11-v0.0.5.mdx
+++ b/apps/docs-site/changelog/2025-02-11-v0.0.5.mdx
@@ -2,8 +2,8 @@
 title: Rewrite plugin in Go
 date: 2025-02-11T15:18:04.000Z
 packages:
-    connect-ktor:
-        version: 0.0.5
+  connect-ktor:
+    version: 0.0.5
 ---
 
 ## Rewrite plugin in Go

--- a/apps/docs-site/changelog/2025-02-12-v0.0.6.mdx
+++ b/apps/docs-site/changelog/2025-02-12-v0.0.6.mdx
@@ -2,8 +2,8 @@
 title: Add proto3 optional feature support
 date: 2025-02-12T15:52:51.000Z
 packages:
-    connect-ktor:
-        version: 0.0.6
+  connect-ktor:
+    version: 0.0.6
 ---
 
 ### Add proto3 optional feature support

--- a/apps/docs-site/changelog/2025-02-13-v0.0.7.mdx
+++ b/apps/docs-site/changelog/2025-02-13-v0.0.7.mdx
@@ -2,8 +2,8 @@
 title: Correct input type in route handler definition
 date: 2025-02-13T15:47:50.000Z
 packages:
-    connect-ktor:
-        version: 0.0.7
+  connect-ktor:
+    version: 0.0.7
 ---
 
 ### Correct input type in route handler definition

--- a/apps/docs-site/changelog/2025-05-11-v0.1.0.mdx
+++ b/apps/docs-site/changelog/2025-05-11-v0.1.0.mdx
@@ -2,8 +2,8 @@
 title: Dependency updates
 date: 2025-05-11T12:56:22.000Z
 packages:
-    connect-ktor:
-        version: 0.1.0
+  connect-ktor:
+    version: 0.1.0
 ---
 
 ## Dependencies

--- a/apps/docs-site/changelog/2025-05-18-v0.1.1.mdx
+++ b/apps/docs-site/changelog/2025-05-18-v0.1.1.mdx
@@ -2,8 +2,8 @@
 title: Dependency updates
 date: 2025-05-18T12:24:31.000Z
 packages:
-    connect-ktor:
-        version: 0.1.1
+  connect-ktor:
+    version: 0.1.1
 ---
 
 ## Dependencies

--- a/apps/docs-site/changelog/2025-06-18-v0.1.2.mdx
+++ b/apps/docs-site/changelog/2025-06-18-v0.1.2.mdx
@@ -2,8 +2,8 @@
 title: Dependency updates
 date: 2025-06-18T15:15:03.000Z
 packages:
-    connect-ktor:
-        version: 0.1.2
+  connect-ktor:
+    version: 0.1.2
 ---
 
 ## Dependencies

--- a/apps/docs-site/changelog/2025-08-05-v0.1.3.mdx
+++ b/apps/docs-site/changelog/2025-08-05-v0.1.3.mdx
@@ -2,8 +2,8 @@
 title: Dependency updates
 date: 2025-08-05T16:27:08.000Z
 packages:
-    connect-ktor:
-        version: 0.1.3
+  connect-ktor:
+    version: 0.1.3
 ---
 
 ## Dependencies

--- a/apps/docs-site/changelog/2025-09-25-v0.1.4.mdx
+++ b/apps/docs-site/changelog/2025-09-25-v0.1.4.mdx
@@ -2,8 +2,8 @@
 title: Dependency updates
 date: 2025-09-25T15:25:51.000Z
 packages:
-    connect-ktor:
-        version: 0.1.4
+  connect-ktor:
+    version: 0.1.4
 ---
 
 ## Dependencies

--- a/apps/docs-site/changelog/2025-10-19-v0.1.5.mdx
+++ b/apps/docs-site/changelog/2025-10-19-v0.1.5.mdx
@@ -2,8 +2,8 @@
 title: Dependency updates
 date: 2025-10-19T07:44:25.000Z
 packages:
-    connect-ktor:
-        version: 0.1.5
+  connect-ktor:
+    version: 0.1.5
 ---
 
 ## Dependencies

--- a/apps/docs-site/changelog/2025-11-15-v0.1.6.mdx
+++ b/apps/docs-site/changelog/2025-11-15-v0.1.6.mdx
@@ -2,8 +2,8 @@
 title: Dependency updates
 date: 2025-11-15T08:49:22.000Z
 packages:
-    connect-ktor:
-        version: 0.1.6
+  connect-ktor:
+    version: 0.1.6
 ---
 
 ## Dependencies

--- a/apps/docs-site/changelog/2025-12-17-v0.1.7.mdx
+++ b/apps/docs-site/changelog/2025-12-17-v0.1.7.mdx
@@ -2,8 +2,8 @@
 title: Dependency updates
 date: 2025-12-17T14:39:09.000Z
 packages:
-    connect-ktor:
-        version: 0.1.7
+  connect-ktor:
+    version: 0.1.7
 ---
 
 ## Dependencies

--- a/apps/docs-site/changelog/2026-01-12-v0.1.8.mdx
+++ b/apps/docs-site/changelog/2026-01-12-v0.1.8.mdx
@@ -2,8 +2,8 @@
 title: Dependency updates
 date: 2026-01-12T08:19:30.000Z
 packages:
-    connect-ktor:
-        version: 0.1.8
+  connect-ktor:
+    version: 0.1.8
 ---
 
 ## Dependencies

--- a/apps/docs-site/changelog/2026-02-12-v0.1.9.mdx
+++ b/apps/docs-site/changelog/2026-02-12-v0.1.9.mdx
@@ -2,8 +2,8 @@
 title: Dependency updates
 date: 2026-02-12T13:43:53.000Z
 packages:
-    connect-ktor:
-        version: 0.1.9
+  connect-ktor:
+    version: 0.1.9
 ---
 
 ## Dependencies

--- a/apps/docs-site/changelog/2026-04-05-v0.1.10.mdx
+++ b/apps/docs-site/changelog/2026-04-05-v0.1.10.mdx
@@ -2,8 +2,8 @@
 title: Dependency updates
 date: 2026-04-05T07:42:23.000Z
 packages:
-    connect-ktor:
-        version: 0.1.10
+  connect-ktor:
+    version: 0.1.10
 ---
 
 ## Dependencies

--- a/apps/docs-site/changelog/2026-05-24-v0.1.11.mdx
+++ b/apps/docs-site/changelog/2026-05-24-v0.1.11.mdx
@@ -2,8 +2,8 @@
 title: Verify Connect protocol compliance against Ktor CIO and Netty
 date: 2026-05-24T15:59:20.000Z
 packages:
-    connect-ktor:
-        version: 0.1.11
+  connect-ktor:
+    version: 0.1.11
 ---
 
 ## Verify Connect protocol compliance against Ktor CIO and Netty

--- a/apps/docs-site/changelog/2026-06-28-v0.2.0.mdx
+++ b/apps/docs-site/changelog/2026-06-28-v0.2.0.mdx
@@ -2,8 +2,8 @@
 title: Support Connect client-streaming RPCs
 date: 2026-06-28T13:31:12.000Z
 packages:
-    connect-ktor:
-        version: 0.2.0
+  connect-ktor:
+    version: 0.2.0
 ---
 
 ## Support Connect client-streaming RPCs (STREAM_TYPE_CLIENT_STREAM)

--- a/apps/docs-site/changelog/2026-07-15-connect-get.mdx
+++ b/apps/docs-site/changelog/2026-07-15-connect-get.mdx
@@ -2,8 +2,8 @@
 title: Support Connect GET for idempotent unary RPCs
 date: 2026-08-02T01:42:04.343Z
 packages:
-    connect-ktor:
-        version: 0.3.0
+  connect-ktor:
+    version: 0.3.0
 ---
 
 ## Support Connect GET for idempotent unary RPCs

--- a/apps/docs-site/changelog/2026-07-25-message-receive-limit.mdx
+++ b/apps/docs-site/changelog/2026-07-25-message-receive-limit.mdx
@@ -2,8 +2,8 @@
 title: Support message receive size limits
 date: 2026-08-02T01:42:04.343Z
 packages:
-    connect-ktor:
-        version: 0.3.0
+  connect-ktor:
+    version: 0.3.0
 ---
 
 ## Support message receive size limits

--- a/apps/docs-site/changelog/2026-07-25-unary-compression.mdx
+++ b/apps/docs-site/changelog/2026-07-25-unary-compression.mdx
@@ -2,8 +2,8 @@
 title: Support unary compression negotiation
 date: 2026-08-02T01:42:04.343Z
 packages:
-    connect-ktor:
-        version: 0.3.0
+  connect-ktor:
+    version: 0.3.0
 ---
 
 ## Support unary compression negotiation

--- a/apps/docs-site/changelog/2026-08-02-dependencies.mdx
+++ b/apps/docs-site/changelog/2026-08-02-dependencies.mdx
@@ -2,8 +2,8 @@
 title: Dependencies
 date: 2026-08-02T01:42:04.343Z
 packages:
-    connect-ktor:
-        version: 0.3.0
+  connect-ktor:
+    version: 0.3.0
 ---
 
 ## Dependencies

--- a/apps/docs-site/content/getting-started.mdx
+++ b/apps/docs-site/content/getting-started.mdx
@@ -43,16 +43,16 @@ Point Buf at the local plugin alongside the usual Java/Kotlin and Connect-Kotlin
 version: v2
 clean: true
 managed:
-    enabled: true
+  enabled: true
 plugins:
-    - remote: buf.build/protocolbuffers/java
-      out: path/to/code
-    - remote: buf.build/protocolbuffers/kotlin
-      out: path/to/code
-    - remote: buf.build/connectrpc/kotlin
-      out: path/to/code
-    - local: protoc-gen-connect-ktor
-      out: path/to/code
+  - remote: buf.build/protocolbuffers/java
+    out: path/to/code
+  - remote: buf.build/protocolbuffers/kotlin
+    out: path/to/code
+  - remote: buf.build/connectrpc/kotlin
+    out: path/to/code
+  - local: protoc-gen-connect-ktor
+    out: path/to/code
 ```
 
 ```bash


### PR DESCRIPTION
## Summary

Two things the open Version Packages PR needs. First, #327 and #328 merged after the pending deps entry was written, so 0.3.1 would ship without them. Second, the `lint-format` failure on that PR is structural, not a one-off: Tegami writes YAML frontmatter at 2 spaces while oxfmt indents markdown at 4, so every changelog file the release workflow generates fails formatting the moment CI commits it. Fixing the indent rule stops the Version Packages PR from going red on every release.

## What changed

- `.tegami/2026-08-31-deps.md`
    - Two bullets appended for [PR #327](https://github.com/ichizero/connect-ktor/pull/327) (docs-site) and [PR #328](https://github.com/ichizero/connect-ktor/pull/328) (protobuf monorepo v4.36.0)
- `.editorconfig`
    - New `[*.{md,mdx}]` section with `indent_size = 2`, alongside the existing `[*.{json,yaml,yml}]` rule, with a comment naming Tegami as the reason
- Reformat fallout from that rule (`pnpm lint-fix`, no hand edits)
    - Frontmatter in the 25 published `apps/docs-site/changelog/*.mdx` and in the pending `.tegami/*.md` entry: `4 → 2` spaces, bodies untouched
    - `CONTRIBUTING.md`: nested ordered list under "Convention for each change" and the two fenced `md` frontmatter examples
    - `README.md` and `apps/docs-site/content/getting-started.mdx`: the embedded `buf.gen.yaml` samples, which now use the 2-space indent real buf configs use
- `CONTRIBUTING.md`
    - New rule bullet stating frontmatter is 2-space indented and why, so the next person does not "fix" it back to 4

## Decision points

| Question | Decision | Why |
| -------- | -------- | --- |
| Why does this only fail in CI? | The lefthook `oxfmt` hook has `stage_fixed: true` | Locally every commit is silently reformatted to 4 spaces, so contributors never see it; the release workflow commits generated files with no hook, so only the Version Packages PR goes red. |
| Fix the generator instead? | No | Both serializers (`yaml.stringify` in `tegami`, `js-yaml.dump` in `@fumapress/tegami`) are called without an `indent` option — 2 is their default and not configurable from this repo. |
| Scope the indent to the generated paths via `.oxfmtrc.json` `overrides`? | No, changed `.editorconfig` instead | An override would keep two indent rules for markdown in the repo, and would still leave `CONTRIBUTING.md`'s fenced examples printed at 4 while the real files are at 2. One rule is simpler and matches the existing `json,yaml,yml = 2` line. |
| Run `pnpm lint-fix` in `release.yml` after `tegami ci`? | No | It papers over the mismatch with an extra CI commit on every release instead of removing it. |
| Does `tabWidth` reach markdown bodies too? | Yes, and that is the intended fallout | Verified the whole diff: only frontmatter, nested list levels, and embedded YAML samples move; no prose rewrapping. |

## Commits

| Commit | Purpose |
| ------ | ------- |
| `1d3a139 docs(changelog): add #327 and #328 to the pending deps entry` | Keeps 0.3.1's changelog complete. |
| `0f377e2 build(format): indent markdown at 2 spaces to match Tegami output` | Removes the recurring `lint-format` failure on generated changelog files. |

## Test plan

- [x] `pnpm lint:format` — `All matched files use the correct format.`
- [x] Dropped the exact MDX generated on `tegami/version-packages` (`apps/docs-site/changelog/2026-08-31-deps.mdx`, 2-space frontmatter) into the tree unmodified and re-ran `pnpm lint:format` — passes, where it fails on `main` today
- [x] Same check with a `pnpm tegami` TUI-shaped pending entry (`packages:` → `connect-ktor:` → `type: patch`, 2-space) — passes; on `main` this fails too, so hand-written entries were the only ones that ever passed
- [x] Reviewed the full 29-file diff: frontmatter, nested lists, and embedded `buf.gen.yaml` samples only
- [ ] `lint-format` green on this PR
- [ ] After merge, the regenerated Version Packages PR passes `lint-format` with no manual reformat commit

---
_Generated by [Claude Code](https://claude.ai/code/session_01DHaEcuXfFFveg43B92nFXk)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidance and configuration examples to use consistent two-space indentation.
  * Reformatted changelog metadata for consistent YAML formatting without changing release information.
  * Added two dependency update entries to the changelog.
* **Chores**
  * Standardized Markdown and MDX formatting rules to reduce generated documentation formatting issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->